### PR TITLE
feat: attachment(file, link) crud 구현 (s3)

### DIFF
--- a/src/main/java/com/rdc/weflow_server/config/S3Config.java
+++ b/src/main/java/com/rdc/weflow_server/config/S3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -19,6 +20,18 @@ public class S3Config {
 
     @Value("${cloud.aws.region}")
     private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
 
     @Bean
     public S3Presigner s3Presigner() {

--- a/src/main/java/com/rdc/weflow_server/controller/attachment/AttachmentController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/attachment/AttachmentController.java
@@ -1,0 +1,69 @@
+package com.rdc.weflow_server.controller.attachment;
+
+import com.rdc.weflow_server.common.api.ApiResponse;
+import com.rdc.weflow_server.dto.attachment.AttachmentFileRequest;
+import com.rdc.weflow_server.dto.attachment.AttachmentLinkRequest;
+import com.rdc.weflow_server.dto.attachment.AttachmentResponse;
+import com.rdc.weflow_server.entity.attachment.Attachment;
+import com.rdc.weflow_server.service.attachment.AttachmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Attachment", description = "첨부파일 API")
+@RestController
+@RequestMapping("/api/attachments")
+@RequiredArgsConstructor
+public class AttachmentController {
+
+    private final AttachmentService attachmentService;
+
+    @Operation(summary = "파일 업로드 완료 후 메타데이터 저장")
+    @PostMapping("/files")
+    public ApiResponse<AttachmentResponse> uploadFile(@RequestBody AttachmentFileRequest request) {
+        AttachmentResponse response = attachmentService.uploadFile(request);
+        return ApiResponse.success("FILE_UPLOADED", response);
+    }
+
+    @Operation(summary = "링크 추가")
+    @PostMapping("/links")
+    public ApiResponse<AttachmentResponse> addLink(@RequestBody AttachmentLinkRequest request) {
+        AttachmentResponse response = attachmentService.addLink(request);
+        return ApiResponse.success("LINK_ADDED", response);
+    }
+
+    @Operation(summary = "첨부파일 다운로드 URL 조회")
+    @GetMapping("/{attachmentId}/download-url")
+    public ApiResponse<String> getDownloadUrl(@PathVariable Long attachmentId) {
+        String downloadUrl = attachmentService.getDownloadUrl(attachmentId);
+        return ApiResponse.success("DOWNLOAD_URL_GENERATED", downloadUrl);
+    }
+
+    @Operation(summary = "첨부파일 삭제")
+    @DeleteMapping("/{attachmentId}")
+    public ApiResponse<Void> deleteAttachment(@PathVariable Long attachmentId) {
+        attachmentService.deleteAttachment(attachmentId);
+        return ApiResponse.success("ATTACHMENT_DELETED", null);
+    }
+
+    @Operation(summary = "특정 대상의 첨부파일 목록 조회")
+    @GetMapping
+    public ApiResponse<List<AttachmentResponse>> getAttachments(
+            @RequestParam Attachment.TargetType targetType,
+            @RequestParam Long targetId
+    ) {
+        List<AttachmentResponse> responses = attachmentService.getAttachments(targetType, targetId);
+        return ApiResponse.success("ATTACHMENTS_RETRIEVED", responses);
+    }
+
+    @Operation(summary = "첨부파일 상세 조회")
+    @GetMapping("/{attachmentId}")
+    public ApiResponse<AttachmentResponse> getAttachment(@PathVariable Long attachmentId) {
+        AttachmentResponse response = attachmentService.getAttachment(attachmentId);
+        return ApiResponse.success("ATTACHMENT_RETRIEVED", response);
+    }
+
+}

--- a/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentFileRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentFileRequest.java
@@ -1,0 +1,15 @@
+package com.rdc.weflow_server.dto.attachment;
+
+import com.rdc.weflow_server.entity.attachment.Attachment;
+import lombok.Getter;
+
+@Getter
+public class AttachmentFileRequest {
+
+    private Attachment.TargetType targetType;
+    private Long targetId;
+    private String filePath;
+    private String fileName;
+    private Long fileSize;
+    private String contentType;
+}

--- a/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentLinkRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentLinkRequest.java
@@ -1,0 +1,12 @@
+package com.rdc.weflow_server.dto.attachment;
+
+import com.rdc.weflow_server.entity.attachment.Attachment;
+import lombok.Getter;
+
+@Getter
+public class AttachmentLinkRequest {
+
+    private Attachment.TargetType targetType;
+    private Long targetId;
+    private String url;
+}

--- a/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentResponse.java
@@ -1,0 +1,38 @@
+package com.rdc.weflow_server.dto.attachment;
+
+import com.rdc.weflow_server.entity.attachment.Attachment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AttachmentResponse {
+
+    private Long id;
+    private Attachment.TargetType targetType;
+    private Long targetId;
+    private Attachment.AttachmentType attachmentType;
+    private String filePath;
+    private String fileName;
+    private Long fileSize;
+    private String contentType;
+    private String url;
+    private LocalDateTime createdAt;
+
+    public static AttachmentResponse from(Attachment attachment) {
+        return AttachmentResponse.builder()
+                .id(attachment.getId())
+                .targetType(attachment.getTargetType())
+                .targetId(attachment.getTargetId())
+                .attachmentType(attachment.getAttachmentType())
+                .filePath(attachment.getFilePath())
+                .fileName(attachment.getFileName())
+                .fileSize(attachment.getFileSize())
+                .contentType(attachment.getContentType())
+                .url(attachment.getUrl())
+                .createdAt(attachment.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/rdc/weflow_server/entity/attachment/Attachment.java
+++ b/src/main/java/com/rdc/weflow_server/entity/attachment/Attachment.java
@@ -22,7 +22,7 @@ public class Attachment extends BaseEntity {
     private TargetType targetType;
 
     /** 첨부 주체 ID (post_id, comment_id, step_request_id 등) */
-    @Column(name = "target_id", nullable = false)
+    @Column(name = "target_id")
     private Long targetId;
 
     /** 첨부 구분: FILE / LINK */

--- a/src/main/java/com/rdc/weflow_server/exception/ErrorCode.java
+++ b/src/main/java/com/rdc/weflow_server/exception/ErrorCode.java
@@ -91,7 +91,10 @@ public enum ErrorCode {
 
     // Checklist Answer
     REQUIRED_ANSWER_INPUT(HttpStatus.BAD_REQUEST, "CHECKLIST_ANSWER_001", "해당 선택지는 추가 입력이 필요합니다."),
-    INVALID_ANSWER_INPUT(HttpStatus.BAD_REQUEST, "CHECKLIST_ANSWER_002", "해당 선택지에는 추가 입력을 허용하지 않습니다.");
+    INVALID_ANSWER_INPUT(HttpStatus.BAD_REQUEST, "CHECKLIST_ANSWER_002", "해당 선택지에는 추가 입력을 허용하지 않습니다."),
+
+    // Attachment
+    ATTACHMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTACHMENT_001", "첨부파일을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/rdc/weflow_server/service/attachment/AttachmentService.java
+++ b/src/main/java/com/rdc/weflow_server/service/attachment/AttachmentService.java
@@ -1,0 +1,111 @@
+package com.rdc.weflow_server.service.attachment;
+
+import com.rdc.weflow_server.dto.attachment.AttachmentFileRequest;
+import com.rdc.weflow_server.dto.attachment.AttachmentLinkRequest;
+import com.rdc.weflow_server.dto.attachment.AttachmentResponse;
+import com.rdc.weflow_server.entity.attachment.Attachment;
+import com.rdc.weflow_server.exception.BusinessException;
+import com.rdc.weflow_server.exception.ErrorCode;
+import com.rdc.weflow_server.repository.attachment.AttachmentRepository;
+import com.rdc.weflow_server.service.file.S3FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AttachmentService {
+
+    private final AttachmentRepository attachmentRepository;
+    private final S3FileService s3FileService;
+
+    /**
+     * 파일 업로드 완료 후 첨부파일 메타데이터 저장
+     */
+    @Transactional
+    public AttachmentResponse uploadFile(AttachmentFileRequest request) {
+        Attachment attachment = Attachment.builder()
+                .targetType(request.getTargetType())
+                .targetId(request.getTargetId())
+                .attachmentType(Attachment.AttachmentType.FILE)
+                .filePath(request.getFilePath())
+                .fileName(request.getFileName())
+                .fileSize(request.getFileSize())
+                .contentType(request.getContentType())
+                .build();
+
+        Attachment saved = attachmentRepository.save(attachment);
+        return AttachmentResponse.from(saved);
+    }
+
+    /**
+     * 링크 추가
+     */
+    @Transactional
+    public AttachmentResponse addLink(AttachmentLinkRequest request) {
+        Attachment attachment = Attachment.builder()
+                .targetType(request.getTargetType())
+                .targetId(request.getTargetId())
+                .attachmentType(Attachment.AttachmentType.LINK)
+                .url(request.getUrl())
+                .build();
+
+        Attachment saved = attachmentRepository.save(attachment);
+        return AttachmentResponse.from(saved);
+    }
+
+    /**
+     * 첨부파일 다운로드 URL 생성
+     */
+    public String getDownloadUrl(Long attachmentId) {
+        Attachment attachment = attachmentRepository.findById(attachmentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ATTACHMENT_NOT_FOUND));
+
+        if (attachment.getAttachmentType() != Attachment.AttachmentType.FILE) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        return s3FileService.generateDownloadPresignedUrl(attachment.getFilePath());
+    }
+
+    /**
+     * 첨부파일 삭제 (DB + S3)
+     */
+    @Transactional
+    public void deleteAttachment(Long attachmentId) {
+        Attachment attachment = attachmentRepository.findById(attachmentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ATTACHMENT_NOT_FOUND));
+
+        // S3 파일 삭제 (파일 타입인 경우에만)
+        if (attachment.getAttachmentType() == Attachment.AttachmentType.FILE
+                && attachment.getFilePath() != null) {
+            s3FileService.deleteFile(attachment.getFilePath());
+        }
+
+        // DB에서 삭제
+        attachmentRepository.delete(attachment);
+    }
+
+    /**
+     * 특정 대상의 첨부파일 목록 조회
+     */
+    public List<AttachmentResponse> getAttachments(Attachment.TargetType targetType, Long targetId) {
+        List<Attachment> attachments = attachmentRepository.findByTargetTypeAndTargetId(targetType, targetId);
+        return attachments.stream()
+                .map(AttachmentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 첨부파일 상세 조회
+     */
+    public AttachmentResponse getAttachment(Long attachmentId) {
+        Attachment attachment = attachmentRepository.findById(attachmentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ATTACHMENT_NOT_FOUND));
+        return AttachmentResponse.from(attachment);
+    }
+}

--- a/src/main/java/com/rdc/weflow_server/service/file/S3FileService.java
+++ b/src/main/java/com/rdc/weflow_server/service/file/S3FileService.java
@@ -4,9 +4,14 @@ import com.rdc.weflow_server.dto.file.PresignedUrlResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.time.Duration;
@@ -16,6 +21,7 @@ import java.time.Duration;
 public class S3FileService {
 
     private final S3Presigner presigner;
+    private final S3Client s3Client;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -42,5 +48,31 @@ public class S3FileService {
                 presignedRequest.url().toString(),
                 key
         );
+    }
+
+    public String generateDownloadPresignedUrl(String key) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5)) // 5분 유효
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        PresignedGetObjectRequest presignedRequest =
+                presigner.presignGetObject(presignRequest);
+
+        return presignedRequest.url().toString();
+    }
+
+    public void deleteFile(String key) {
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
     }
 }


### PR DESCRIPTION
- AttachmentController, AttachmentService, DTO 추가
- S3 파일 다운로드 presigned URL 생성 기능 추가
- S3 파일 삭제 기능 추가
- S3Client 빈 설정 추가
- ATTACHMENT_NOT_FOUND 에러코드 추가

## Endpoint
Presigned URL 발급: GET api/files/presigned-url
파일 메타데이터 저장: POST /api/attachments/files
링크 추가: POST /api/attachments/links
파일 다운로드 URL 조회: GET /api/attachments/{attachmentId}/download-url
첨부파일 삭제: DELETE /api/attachments/{attachmentId}
첨부파일 목록 조회: GET /api/attachments
첨부파일 상세 조회: GET /api/attachments/{attachmentId}