### PR TITLE
feat: post question/answer 기능 추가

### DIFF
--- a/src/main/java/com/rdc/weflow_server/controller/post/PostController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/post/PostController.java
@@ -1,11 +1,7 @@
 package com.rdc.weflow_server.controller.post;
 
 import com.rdc.weflow_server.common.api.ApiResponse;
-import com.rdc.weflow_server.dto.post.PostCreateRequest;
-import com.rdc.weflow_server.dto.post.PostCreateResponse;
-import com.rdc.weflow_server.dto.post.PostDetailResponse;
-import com.rdc.weflow_server.dto.post.PostListResponse;
-import com.rdc.weflow_server.dto.post.PostUpdateRequest;
+import com.rdc.weflow_server.dto.post.*;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import com.rdc.weflow_server.service.post.PostService;
 import lombok.RequiredArgsConstructor;
@@ -77,6 +73,45 @@ public class PostController {
     ) {
         postService.deletePost(projectId, postId);
         return ResponseEntity.ok(ApiResponse.success("게시글 삭제 성공", null));
+    }
+
+    /**
+     * 질문에 대한 답변 등록
+     */
+    @PostMapping("/{postId}/questions/{questionId}/answer")
+    public ResponseEntity<ApiResponse<PostAnswerResponse>> answerQuestion(
+            @PathVariable Long projectId,
+            @PathVariable Long postId,
+            @PathVariable Long questionId,
+            @RequestBody PostAnswerRequest request
+    ) {
+        PostAnswerResponse response = postService.answerQuestion(projectId, postId, questionId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("답변 등록 성공", response));
+    }
+
+    /**
+     * 게시글 승인 상태 변경 (CONFIRMED/REJECTED)
+     */
+    @PatchMapping("/{postId}/status")
+    public ResponseEntity<ApiResponse<Void>> updatePostStatus(
+            @PathVariable Long projectId,
+            @PathVariable Long postId,
+            @RequestBody PostStatusUpdateRequest request
+    ) {
+        postService.updatePostStatus(projectId, postId, request);
+        return ResponseEntity.ok(ApiResponse.success("게시글 상태 변경 성공", null));
+    }
+
+    /**
+     * 게시글 완료 (OPEN -> CLOSED)
+     */
+    @PatchMapping("/{postId}/close")
+    public ResponseEntity<ApiResponse<Void>> closePost(
+            @PathVariable Long projectId,
+            @PathVariable Long postId
+    ) {
+        postService.closePost(projectId, postId);
+        return ResponseEntity.ok(ApiResponse.success("게시글 완료 처리 성공", null));
     }
 
 }

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostAnswerRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostAnswerRequest.java
@@ -1,0 +1,16 @@
+package com.rdc.weflow_server.dto.post;
+
+import com.rdc.weflow_server.entity.post.AnswerType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostAnswerRequest {
+
+    private AnswerType answerType;
+    private String content;  // 사유/의견 (선택사항)
+
+}

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostAnswerResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostAnswerResponse.java
@@ -1,0 +1,33 @@
+package com.rdc.weflow_server.dto.post;
+
+import com.rdc.weflow_server.entity.post.AnswerType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostAnswerResponse {
+
+    private Long answerId;
+    private AnswerType answerType;
+    private String content;
+    private RespondentDto respondent;
+    private LocalDateTime createdAt;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RespondentDto {
+        private Long memberId;
+        private String name;
+        private String role;
+    }
+
+}

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostStatusUpdateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostStatusUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.rdc.weflow_server.dto.post;
+
+import com.rdc.weflow_server.entity.post.PostApprovalStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostStatusUpdateRequest {
+
+    private PostApprovalStatus status;
+
+}

--- a/src/main/java/com/rdc/weflow_server/entity/post/Post.java
+++ b/src/main/java/com/rdc/weflow_server/entity/post/Post.java
@@ -32,7 +32,7 @@ public class Post extends BaseEntity {
     private ProjectStatus projectStatus; // 게시글이 어떤 phase에 속해있는지 계약-진행-납품-유지보수
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false) // TODO: DELETED 없애도 될 것 같아요. 나중에 확인 @Jaehee
     private PostApprovalStatus status; // NORMAL, WAITING_CONFIRM, CONFIRMED, REJECTED, DELETED
 
     @Enumerated(EnumType.STRING)
@@ -66,6 +66,10 @@ public class Post extends BaseEntity {
 
     public void updateStatus(PostApprovalStatus status) {
         this.status = status;
+    }
+
+    public void closePost() {
+        this.openStatus = PostOpenStatus.CLOSED;
     }
 
 }

--- a/src/main/java/com/rdc/weflow_server/entity/post/PostAnswer.java
+++ b/src/main/java/com/rdc/weflow_server/entity/post/PostAnswer.java
@@ -3,11 +3,15 @@ package com.rdc.weflow_server.entity.post;
 import com.rdc.weflow_server.entity.BaseEntity;
 import com.rdc.weflow_server.entity.user.User;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "post_answers")
 public class PostAnswer extends BaseEntity {

--- a/src/main/java/com/rdc/weflow_server/exception/ErrorCode.java
+++ b/src/main/java/com/rdc/weflow_server/exception/ErrorCode.java
@@ -17,6 +17,14 @@ public enum ErrorCode {
     // Post
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_001", "게시글을 찾을 수 없습니다."),
     POST_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "POST_002", "이미 삭제된 게시글입니다."),
+    POST_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "POST_003", "이미 완료된 게시글입니다."),
+    INVALID_POST_STATUS(HttpStatus.BAD_REQUEST, "POST_004", "게시글 상태가 올바르지 않습니다."),
+
+    // Post Question
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_001", "질문을 찾을 수 없습니다."),
+
+    // Post Answer
+    ANSWER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ANSWER_001", "이미 답변이 등록되었습니다."),
 
     // Company
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANY_001", "회사를 찾을 수 없습니다."),


### PR DESCRIPTION
게시글 질문 답변 기능 추가

## Endpoint
- 질문 답변 :  POST /api/projects/{projectId}/posts/{postId}/questions/{questionId}/answer
- 게시글 승인 상태 변경: PATCH /api/projects/{projectId}/posts/{postId}/status
- 게시글 완료: PATCH /api/projects/{projectId}/posts/{postId}/close

## 기타
- ErrorCode 추가: QUESTION_NOT_FOUND, ANSWER_ALREADY_EXISTS, POST_ALREADY_CLOSED, INVALID_POST_STATUS
- Post 엔티티에 closePost() 메서드 추가

## 설명
1. 질문 답변에서 
- 반대 역할(CLIENT ↔ AGENCY) 답변 가능, SYSTEM_ADMIN은 모든 질문 답변 가능

2. 게시글 승인 상태 변경
- 작성자만 WAITING_CONFIRM 상태를 CONFIRMED/REJECTED로 변경 가능

3. 게시글 완료 (Open, Closed)
- 작성자만 OPEN → CLOSED 상태 변경 가능
