### PR TITLE
feat: Integrate ActivityLog into Step Domain

### DIFF
--- a/src/main/java/com/rdc/weflow_server/controller/step/StepRequestAnswerController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/step/StepRequestAnswerController.java
@@ -4,7 +4,9 @@ import com.rdc.weflow_server.common.api.ApiResponse;
 import com.rdc.weflow_server.config.security.CustomUserDetails;
 import com.rdc.weflow_server.dto.step.StepRequestAnswerCreateRequest;
 import com.rdc.weflow_server.dto.step.StepRequestAnswerResponse;
+import com.rdc.weflow_server.service.log.AuditContext;
 import com.rdc.weflow_server.service.step.StepRequestAnswerService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,8 +29,10 @@ public class StepRequestAnswerController {
     @PostMapping("/requests/{requestId}/feedback")
     public ApiResponse<StepRequestAnswerResponse> answerRequest(@PathVariable Long requestId,
                                                                 @AuthenticationPrincipal CustomUserDetails user,
-                                                                @RequestBody @Valid StepRequestAnswerCreateRequest request) {
-        StepRequestAnswerResponse response = stepRequestAnswerService.answerRequest(requestId, user.getId(), request);
+                                                                @RequestBody @Valid StepRequestAnswerCreateRequest request,
+                                                                HttpServletRequest httpRequest) {
+        AuditContext ctx = new AuditContext(user.getId(), httpRequest.getRemoteAddr(), null);
+        StepRequestAnswerResponse response = stepRequestAnswerService.answerRequest(requestId, ctx, request);
         return ApiResponse.success("stepRequestAnswer.create.success", response);
     }
 

--- a/src/main/java/com/rdc/weflow_server/controller/step/StepRequestController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/step/StepRequestController.java
@@ -6,7 +6,9 @@ import com.rdc.weflow_server.dto.step.StepRequestCreateRequest;
 import com.rdc.weflow_server.dto.step.StepRequestListResponse;
 import com.rdc.weflow_server.dto.step.StepRequestResponse;
 import com.rdc.weflow_server.dto.step.StepRequestUpdateRequest;
+import com.rdc.weflow_server.service.log.AuditContext;
 import com.rdc.weflow_server.service.step.StepRequestService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -31,8 +33,10 @@ public class StepRequestController {
     @PostMapping("/steps/{stepId}/requests")
     public ApiResponse<StepRequestResponse> createRequest(@PathVariable Long stepId,
                                                           @AuthenticationPrincipal CustomUserDetails user,
-                                                          @RequestBody @Valid StepRequestCreateRequest request) {
-        StepRequestResponse response = stepRequestService.createRequest(stepId, user.getId(), request);
+                                                          @RequestBody @Valid StepRequestCreateRequest request,
+                                                          HttpServletRequest httpRequest) {
+        AuditContext ctx = new AuditContext(user.getId(), httpRequest.getRemoteAddr(), null);
+        StepRequestResponse response = stepRequestService.createRequest(stepId, ctx, request);
         return ApiResponse.success("stepRequest.create.success", response);
     }
 
@@ -57,15 +61,19 @@ public class StepRequestController {
     @PatchMapping("/requests/{requestId}")
     public ApiResponse<StepRequestResponse> updateRequest(@PathVariable Long requestId,
                                                           @AuthenticationPrincipal CustomUserDetails user,
-                                                          @RequestBody @Valid StepRequestUpdateRequest request) {
-        StepRequestResponse response = stepRequestService.updateRequest(requestId, user.getId(), request);
+                                                          @RequestBody @Valid StepRequestUpdateRequest request,
+                                                          HttpServletRequest httpRequest) {
+        AuditContext ctx = new AuditContext(user.getId(), httpRequest.getRemoteAddr(), null);
+        StepRequestResponse response = stepRequestService.updateRequest(requestId, ctx, request);
         return ApiResponse.success("stepRequest.update.success", response);
     }
 
     @DeleteMapping("/requests/{requestId}")
     public ApiResponse<Void> cancelRequest(@PathVariable Long requestId,
-                                           @AuthenticationPrincipal CustomUserDetails user) {
-        stepRequestService.cancelRequest(requestId, user.getId());
+                                           @AuthenticationPrincipal CustomUserDetails user,
+                                           HttpServletRequest httpRequest) {
+        AuditContext ctx = new AuditContext(user.getId(), httpRequest.getRemoteAddr(), null);
+        stepRequestService.cancelRequest(requestId, ctx);
         return ApiResponse.success("stepRequest.cancel.success", null);
     }
 }

--- a/src/main/java/com/rdc/weflow_server/service/log/AuditContext.java
+++ b/src/main/java/com/rdc/weflow_server/service/log/AuditContext.java
@@ -1,0 +1,11 @@
+package com.rdc.weflow_server.service.log;
+
+/**
+ * 로그 기록에 필요한 공통 컨텍스트를 담는 경량 DTO.
+ */
+public record AuditContext(
+        Long userId,
+        String ipAddress,
+        Long projectId
+) {
+}


### PR DESCRIPTION
	•	AuditContext(userId, ipAddress, projectId) 도입 → 컨트롤러에서 생성해 서비스로 전달
	•	Step/StepRequest/StepRequestAnswer 전체에 ActivityLog 연동
	•	CREATE / UPDATE / DELETE / SUBMIT / APPROVE / REJECT 등 액션 매핑 적용
	•	재정렬은 UPDATE / STEP / targetId=null 로 기록
	•	첨부/링크 로그 추가
	•	업로드: UPLOAD / ATTACHMENT / attachmentId
	•	삭제/교체: REMOVE / ATTACHMENT / attachmentId
	•	필요 시 일괄 삭제 요약: REMOVE / STEP_REQUEST / requestId
	•	서비스 시그니처 Servlet 의존 제거 → AuditContext 기반으로 통일