### PR TITLE
refactor: remove redundant ResponseEntity wrapper from PostController

### DIFF
--- a/src/main/java/com/rdc/weflow_server/controller/auth/AuthController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/auth/AuthController.java
@@ -6,7 +6,6 @@ import com.rdc.weflow_server.dto.auth.response.LoginResponse;
 import com.rdc.weflow_server.service.auth.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,8 +23,8 @@ public class AuthController {
      * POST /api/auth/login
      */
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
-        return ResponseEntity.ok(ApiResponse.success("로그인에 성공했습니다.", response));
+        return ApiResponse.success("로그인에 성공했습니다.", response);
     }
 }

--- a/src/main/java/com/rdc/weflow_server/controller/comment/CommentController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/comment/CommentController.java
@@ -8,7 +8,6 @@ import com.rdc.weflow_server.dto.comment.ReplyListResponse;
 import com.rdc.weflow_server.service.comment.CommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -21,57 +20,57 @@ public class CommentController {
      * 댓글 목록 조회
      */
     @GetMapping("/api/posts/{postId}/comments")
-    public ResponseEntity<ApiResponse<CommentListResponse>> getComments(@PathVariable Long postId) {
+    public ApiResponse<CommentListResponse> getComments(@PathVariable Long postId) {
         CommentListResponse response = commentService.getComments(postId);
-        return ResponseEntity.ok(ApiResponse.success("댓글 목록 조회 성공", response));
+        return ApiResponse.success("댓글 목록 조회 성공", response);
     }
 
     /**
      * 댓글 작성
      */
     @PostMapping("/api/posts/{postId}/comments")
-    public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<CommentCreateResponse> createComment(
             @PathVariable Long postId,
             @RequestBody CommentCreateRequest request
     ) {
         CommentCreateResponse response = commentService.createComment(postId, request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success("댓글 작성 성공", response));
+        return ApiResponse.success("댓글 작성 성공", response);
     }
 
     /**
      * 대댓글 페이징 조회
      */
     @GetMapping("/api/comments/{commentId}/replies")
-    public ResponseEntity<ApiResponse<ReplyListResponse>> getReplies(
+    public ApiResponse<ReplyListResponse> getReplies(
             @PathVariable Long commentId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         ReplyListResponse response = commentService.getReplies(commentId, page, size);
-        return ResponseEntity.ok(ApiResponse.success("대댓글 조회 성공", response));
+        return ApiResponse.success("대댓글 조회 성공", response);
     }
 
     /**
      * 대댓글 작성
      */
     @PostMapping("/api/comments/{commentId}/replies")
-    public ResponseEntity<ApiResponse<CommentCreateResponse>> createReply(
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<CommentCreateResponse> createReply(
             @PathVariable Long commentId,
             @RequestBody CommentCreateRequest request
     ) {
         CommentCreateResponse response = commentService.createReply(commentId, request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success("대댓글 작성 성공", response));
+        return ApiResponse.success("대댓글 작성 성공", response);
     }
 
     /**
      * 댓글 삭제
      */
     @DeleteMapping("/api/comments/{commentId}")
-    public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable Long commentId) {
+    public ApiResponse<Void> deleteComment(@PathVariable Long commentId) {
         commentService.deleteComment(commentId);
-        return ResponseEntity.ok(ApiResponse.success("댓글 삭제 성공", null));
+        return ApiResponse.success("댓글 삭제 성공", null);
     }
 
 }

--- a/src/main/java/com/rdc/weflow_server/controller/post/PostController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/post/PostController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -50,6 +51,7 @@ public class PostController {
      * 게시글 작성
      */
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<PostCreateResponse> createPost(
             @PathVariable Long projectId,
             @RequestBody PostCreateRequest request
@@ -87,6 +89,7 @@ public class PostController {
      * 질문에 대한 답변 등록
      */
     @PostMapping("/{postId}/questions/{questionId}/answer")
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<PostAnswerResponse> answerQuestion(
             @PathVariable Long projectId,
             @PathVariable Long postId,

--- a/src/main/java/com/rdc/weflow_server/controller/post/PostController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/post/PostController.java
@@ -8,8 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -23,16 +21,16 @@ public class PostController {
      * 게시글 상세 조회 (1개)
      */
     @GetMapping("/{postId}")
-    public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(@PathVariable Long projectId, @PathVariable Long postId) {
+    public ApiResponse<PostDetailResponse> getPost(@PathVariable Long projectId, @PathVariable Long postId) {
         PostDetailResponse response = postService.getPost(projectId, postId);
-        return ResponseEntity.ok(ApiResponse.success("게시글 조회 성공", response));
+        return ApiResponse.success("게시글 조회 성공", response);
     }
 
     /**
      * 게시글 리스트 조회
      */
     @GetMapping
-    public ResponseEntity<ApiResponse<PostListResponse>> getPosts(
+    public ApiResponse<PostListResponse> getPosts(
             @PathVariable Long projectId,
             @RequestParam(required = false) ProjectStatus projectStatus,
             @RequestParam(required = false) Long stepId,
@@ -45,83 +43,83 @@ public class PostController {
         Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sortBy));
 
         PostListResponse response = postService.getPosts(projectId, projectStatus, stepId, pageable);
-        return ResponseEntity.ok(ApiResponse.success("게시글 목록 조회 성공", response));
+        return ApiResponse.success("게시글 목록 조회 성공", response);
     }
 
     /**
      * 게시글 작성
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<PostCreateResponse>> createPost(
+    public ApiResponse<PostCreateResponse> createPost(
             @PathVariable Long projectId,
             @RequestBody PostCreateRequest request
     ) {
         PostCreateResponse response = postService.createPost(projectId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("게시글 작성 성공", response));
+        return ApiResponse.success("게시글 작성 성공", response);
     }
 
     /**
      * 게시글 수정
      */
     @PatchMapping("/{postId}")
-    public ResponseEntity<ApiResponse<PostDetailResponse>> updatePost(
+    public ApiResponse<PostDetailResponse> updatePost(
             @PathVariable Long projectId,
             @PathVariable Long postId,
             @RequestBody PostUpdateRequest request
     ) {
         PostDetailResponse response = postService.updatePost(projectId, postId, request);
-        return ResponseEntity.ok(ApiResponse.success("게시글 수정 성공", response));
+        return ApiResponse.success("게시글 수정 성공", response);
     }
 
     /**
      * 게시글 삭제 (Soft Delete)
      */
     @DeleteMapping("/{postId}")
-    public ResponseEntity<ApiResponse<Void>> deletePost(
+    public ApiResponse<Void> deletePost(
             @PathVariable Long projectId,
             @PathVariable Long postId
     ) {
         postService.deletePost(projectId, postId);
-        return ResponseEntity.ok(ApiResponse.success("게시글 삭제 성공", null));
+        return ApiResponse.success("게시글 삭제 성공", null);
     }
 
     /**
      * 질문에 대한 답변 등록
      */
     @PostMapping("/{postId}/questions/{questionId}/answer")
-    public ResponseEntity<ApiResponse<PostAnswerResponse>> answerQuestion(
+    public ApiResponse<PostAnswerResponse> answerQuestion(
             @PathVariable Long projectId,
             @PathVariable Long postId,
             @PathVariable Long questionId,
             @RequestBody PostAnswerRequest request
     ) {
         PostAnswerResponse response = postService.answerQuestion(projectId, postId, questionId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("답변 등록 성공", response));
+        return ApiResponse.success("답변 등록 성공", response);
     }
 
     /**
      * 게시글 승인 상태 변경 (CONFIRMED/REJECTED)
      */
     @PatchMapping("/{postId}/status")
-    public ResponseEntity<ApiResponse<Void>> updatePostStatus(
+    public ApiResponse<Void> updatePostStatus(
             @PathVariable Long projectId,
             @PathVariable Long postId,
             @RequestBody PostStatusUpdateRequest request
     ) {
         postService.updatePostStatus(projectId, postId, request);
-        return ResponseEntity.ok(ApiResponse.success("게시글 상태 변경 성공", null));
+        return ApiResponse.success("게시글 상태 변경 성공", null);
     }
 
     /**
      * 게시글 완료 (OPEN -> CLOSED)
      */
     @PatchMapping("/{postId}/close")
-    public ResponseEntity<ApiResponse<Void>> closePost(
+    public ApiResponse<Void> closePost(
             @PathVariable Long projectId,
             @PathVariable Long postId
     ) {
         postService.closePost(projectId, postId);
-        return ResponseEntity.ok(ApiResponse.success("게시글 완료 처리 성공", null));
+        return ApiResponse.success("게시글 완료 처리 성공", null);
     }
 
 }


### PR DESCRIPTION
- PostController의 모든 메서드 반환 타입을 ResponseEntity<ApiResponse<T>>에서 ApiResponse<T>로 변경하여 불필요한 래핑 제거