### PR TITLE
fix: file download

### DIFF
--- a/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentLinkRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentLinkRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class AttachmentLinkRequest {
 
-    private Attachment.TargetType targetType;
+    private Attachment.TargetType targetType; // 어떤 엔티티에 속하는 첨부인지 (Post, Step, Support)
     private Long targetId;
-    private String url;
+    private String url; // https://www.google.com
 }

--- a/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/attachment/AttachmentResponse.java
@@ -14,11 +14,11 @@ public class AttachmentResponse {
     private Attachment.TargetType targetType;
     private Long targetId;
     private Attachment.AttachmentType attachmentType;
-    private String filePath;
+    private String filePath; // 첨부 파일의 경로
     private String fileName;
     private Long fileSize;
     private String contentType;
-    private String url;
+    private String url; // 첨부 link의 url
     private LocalDateTime createdAt;
 
     public static AttachmentResponse from(Attachment attachment) {

--- a/src/main/java/com/rdc/weflow_server/service/attachment/AttachmentService.java
+++ b/src/main/java/com/rdc/weflow_server/service/attachment/AttachmentService.java
@@ -69,7 +69,7 @@ public class AttachmentService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        return s3FileService.generateDownloadPresignedUrl(attachment.getFilePath());
+        return s3FileService.generateDownloadPresignedUrl(attachment.getFilePath(), attachment.getFileName());
     }
 
     /**

--- a/src/main/java/com/rdc/weflow_server/service/file/S3FileService.java
+++ b/src/main/java/com/rdc/weflow_server/service/file/S3FileService.java
@@ -50,10 +50,11 @@ public class S3FileService {
         );
     }
 
-    public String generateDownloadPresignedUrl(String key) {
+    public String generateDownloadPresignedUrl(String key, String fileName) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
+                .responseContentDisposition("attachment; filename=\"" + fileName + "\"")
                 .build();
 
         GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()


### PR DESCRIPTION
  ## Summary
  파일 다운로드 개선: 원본 파일명 유지 및 브라우저 즉시 다운로드 지원

  ## Changes
  - S3 presigned URL 생성 시 `Content-Disposition: attachment` 헤더 추가
  - 다운로드 시 원본 파일명 유지되도록 `fileName` 파라미터 전달
  - 관련 DTO에 주석 추가

  ## Impact
  - **Before**: 파일 다운로드 시 UUID 기반 파일명으로 저장되거나 브라우저에서 새 창으로 열림
  - **After**: 원본 파일명으로 즉시 다운로드, 향상된 사용자 경험

  ## Modified Files
  - `S3FileService.java`: `generateDownloadPresignedUrl()` 메서드 개선
  - `AttachmentService.java`: 파일명 전달 로직 추가
  - `AttachmentLinkRequest.java`, `AttachmentResponse.java`: 주석 추가
