### PR TITLE
fix: project phase

### DIFF
--- a/src/main/java/com/rdc/weflow_server/controller/post/PostController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/post/PostController.java
@@ -2,7 +2,8 @@ package com.rdc.weflow_server.controller.post;
 
 import com.rdc.weflow_server.common.api.ApiResponse;
 import com.rdc.weflow_server.dto.post.*;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.post.PostOpenStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.service.post.PostService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,8 @@ public class PostController {
     @GetMapping
     public ApiResponse<PostListResponse> getPosts(
             @PathVariable Long projectId,
-            @RequestParam(required = false) ProjectStatus projectStatus,
+            @RequestParam(required = false) ProjectPhase projectPhase,
+            @RequestParam(required = false) PostOpenStatus openStatus,
             @RequestParam(required = false) Long stepId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -44,7 +46,7 @@ public class PostController {
         Sort.Direction sortDirection = Sort.Direction.fromString(direction);
         Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sortBy));
 
-        PostListResponse response = postService.getPosts(projectId, projectStatus, stepId, pageable);
+        PostListResponse response = postService.getPosts(projectId, projectPhase, openStatus, stepId, pageable);
         return ApiResponse.success("게시글 목록 조회 성공", response);
     }
 

--- a/src/main/java/com/rdc/weflow_server/controller/project/AdminProjectController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/project/AdminProjectController.java
@@ -6,6 +6,7 @@ import com.rdc.weflow_server.dto.project.request.AdminProjectCreateRequest;
 import com.rdc.weflow_server.dto.project.request.AdminProjectMemberAddRequest;
 import com.rdc.weflow_server.dto.project.request.AdminProjectUpdateRequest;
 import com.rdc.weflow_server.dto.project.response.*;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import com.rdc.weflow_server.service.project.AdminProjectService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,13 +41,14 @@ public class AdminProjectController {
     // 프로젝트 목록 조회
     @GetMapping
     public ApiResponse<AdminProjectListResponse> getProjects(
+            @RequestParam(required = false) ProjectPhase phase,
             @RequestParam(required = false) ProjectStatus status,
             @RequestParam(required = false) Long companyId,
             @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
-        AdminProjectListResponse response = adminProjectService.getProjectList(status, companyId, keyword, page, size);
+        AdminProjectListResponse response = adminProjectService.getProjectList(phase, status, companyId, keyword, page, size);
         return ApiResponse.success("PROJECT_LIST_FETCHED", response);
     }
 

--- a/src/main/java/com/rdc/weflow_server/controller/step/AdminStepController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/step/AdminStepController.java
@@ -7,7 +7,7 @@ import com.rdc.weflow_server.dto.step.StepListResponse;
 import com.rdc.weflow_server.dto.step.StepReorderRequest;
 import com.rdc.weflow_server.dto.step.StepResponse;
 import com.rdc.weflow_server.dto.step.StepUpdateRequest;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.service.log.AuditContext;
 import com.rdc.weflow_server.service.step.StepService;
 import jakarta.validation.Valid;
@@ -34,6 +34,30 @@ public class AdminStepController {
 
     private final StepService stepService;
 
+    /**
+     * Step list 조회
+     */
+    @GetMapping("/projects/{projectId}/steps")
+    public ApiResponse<StepListResponse> getSteps(@PathVariable Long projectId,
+                                                  @RequestParam(name = "phase", required = false) ProjectPhase phase) {
+        StepListResponse response = (phase != null)
+                ? stepService.getStepsByProject(projectId, phase)
+                : stepService.getStepsByProject(projectId);
+        return ApiResponse.success("step.list.success", response);
+    }
+
+    /**
+     * Step 상세 조회
+     */
+    @GetMapping("/steps/{stepId}")
+    public ApiResponse<StepResponse> getStep(@PathVariable Long stepId) {
+        StepResponse response = stepService.getStep(stepId);
+        return ApiResponse.success("step.get.success", response);
+    }
+
+    /**
+     * Step 생성
+     */
     @PostMapping("/projects/{projectId}/steps")
     public ApiResponse<StepResponse> createStep(@PathVariable Long projectId,
                                                 @AuthenticationPrincipal CustomUserDetails user,
@@ -44,21 +68,9 @@ public class AdminStepController {
         return ApiResponse.success("step.create.success", response);
     }
 
-    @GetMapping("/projects/{projectId}/steps")
-    public ApiResponse<StepListResponse> getSteps(@PathVariable Long projectId,
-                                                  @RequestParam(name = "phase", required = false) ProjectStatus phase) {
-        StepListResponse response = (phase != null)
-                ? stepService.getStepsByProject(projectId, phase)
-                : stepService.getStepsByProject(projectId);
-        return ApiResponse.success("step.list.success", response);
-    }
-
-    @GetMapping("/steps/{stepId}")
-    public ApiResponse<StepResponse> getStep(@PathVariable Long stepId) {
-        StepResponse response = stepService.getStep(stepId);
-        return ApiResponse.success("step.get.success", response);
-    }
-
+    /**
+     * Step 수정
+     */
     @PatchMapping("/steps/{stepId}")
     public ApiResponse<StepResponse> updateStep(@PathVariable Long stepId,
                                                 @AuthenticationPrincipal CustomUserDetails user,
@@ -69,6 +81,9 @@ public class AdminStepController {
         return ApiResponse.success("step.update.success", response);
     }
 
+    /**
+     * Step 삭제
+     */
     @DeleteMapping("/steps/{stepId}")
     public ApiResponse<Void> deleteStep(@PathVariable Long stepId,
                                         @AuthenticationPrincipal CustomUserDetails user,
@@ -78,6 +93,9 @@ public class AdminStepController {
         return ApiResponse.success("step.delete.success", null);
     }
 
+    /**
+     * Step 순서 바꾸기
+     */
     @PatchMapping("/steps/reorder")
     public ApiResponse<Void> reorderSteps(@AuthenticationPrincipal CustomUserDetails user,
                                           @RequestBody @Valid StepReorderRequest request,

--- a/src/main/java/com/rdc/weflow_server/controller/step/StepController.java
+++ b/src/main/java/com/rdc/weflow_server/controller/step/StepController.java
@@ -3,7 +3,7 @@ package com.rdc.weflow_server.controller.step;
 import com.rdc.weflow_server.common.api.ApiResponse;
 import com.rdc.weflow_server.dto.step.StepListResponse;
 import com.rdc.weflow_server.dto.step.StepResponse;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.service.step.StepService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -24,7 +24,7 @@ public class StepController {
     // 프로젝트 단계 목록 조회
     @GetMapping(value = "/projects/{projectId}/steps")
     public ApiResponse<StepListResponse> getStepsByProject(@PathVariable Long projectId,
-                                                           @RequestParam(name = "phase", required = false) ProjectStatus phase) {
+                                                           @RequestParam(name = "phase", required = false) ProjectPhase phase) {
         StepListResponse response = (phase != null)
                 ? stepService.getStepsByProject(projectId, phase)
                 : stepService.getStepsByProject(projectId);

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostCreateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostCreateRequest.java
@@ -1,6 +1,6 @@
 package com.rdc.weflow_server.dto.post;
 
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +16,7 @@ public class PostCreateRequest {
     private String content;
     private Long stepId;
     private Long parentPostId; // 답글인 경우
-    private ProjectStatus projectStatus;
+    private ProjectPhase projectPhase;
     private List<FileRequest> files;
     private List<LinkRequest> links;
     private List<QuestionRequest> questions;

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostDetailResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostDetailResponse.java
@@ -1,7 +1,8 @@
 package com.rdc.weflow_server.dto.post;
 
 import com.rdc.weflow_server.entity.post.PostApprovalStatus;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.post.PostOpenStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,8 +21,9 @@ public class PostDetailResponse {
     private String title;
     private String content;
     private PostApprovalStatus status;
+    private PostOpenStatus openStatus;
     private AuthorDto author;
-    private ProjectStatus projectStatus;
+    private ProjectPhase projectPhase;
     private StepDto step;
     private List<FileDto> files;
     private List<LinkDto> links;

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostListResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostListResponse.java
@@ -1,7 +1,7 @@
 package com.rdc.weflow_server.dto.post;
 
 import com.rdc.weflow_server.entity.post.PostApprovalStatus;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,7 +27,7 @@ public class PostListResponse {
         private Long postId;
         private String title;
         private PostApprovalStatus status;
-        private ProjectStatus projectStatus;
+        private ProjectPhase projectPhase;
         private Long stepId;
         private AuthorDto author;
         private Boolean hasFiles;

--- a/src/main/java/com/rdc/weflow_server/dto/project/request/AdminProjectCreateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/project/request/AdminProjectCreateRequest.java
@@ -3,6 +3,7 @@ package com.rdc.weflow_server.dto.project.request;
 import com.rdc.weflow_server.dto.step.StepCreateRequest;
 import com.rdc.weflow_server.entity.company.Company;
 import com.rdc.weflow_server.entity.project.Project;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ public class AdminProjectCreateRequest {
 
     private String name;
     private String description;
-    private ProjectStatus status;
+    private ProjectPhase phase;
 
     private LocalDateTime startDate;
     private LocalDateTime endDateExpected;
@@ -33,7 +34,8 @@ public class AdminProjectCreateRequest {
         return Project.builder()
                 .name(name)
                 .description(description)
-                .status(status)
+                .phase(phase != null ? phase : ProjectPhase.CONTRACT) // null이면 기본값 CONTRACT
+                .status(ProjectStatus.OPEN) // 생성 시 항상 OPEN
                 .startDate(startDate)
                 .endDate(null)
                 .expectedEndDate(endDateExpected)

--- a/src/main/java/com/rdc/weflow_server/dto/project/request/AdminProjectUpdateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/project/request/AdminProjectUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.rdc.weflow_server.dto.project.request;
 
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ public class AdminProjectUpdateRequest {
 
     private String name;
     private String description;
+    private ProjectPhase phase;
     private ProjectStatus status;
 
     private LocalDateTime startDate;

--- a/src/main/java/com/rdc/weflow_server/dto/project/response/AdminProjectCreateResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/project/response/AdminProjectCreateResponse.java
@@ -1,6 +1,7 @@
 package com.rdc.weflow_server.dto.project.response;
 
 import com.rdc.weflow_server.entity.project.Project;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class AdminProjectCreateResponse {
 
     private Long id;
     private String name;
+    private ProjectPhase phase;
     private ProjectStatus status;
     private LocalDateTime createdAt;
 
@@ -20,6 +22,7 @@ public class AdminProjectCreateResponse {
         return AdminProjectCreateResponse.builder()
                 .id(project.getId())
                 .name(project.getName())
+                .phase(project.getPhase())
                 .status(project.getStatus())
                 .createdAt(project.getCreatedAt())
                 .build();

--- a/src/main/java/com/rdc/weflow_server/dto/project/response/AdminProjectDetailResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/project/response/AdminProjectDetailResponse.java
@@ -14,6 +14,7 @@ public class AdminProjectDetailResponse {
     private Long id;
     private String name;
     private String description;
+    private String phase;
     private String status;
 
     private LocalDateTime startDate;
@@ -39,6 +40,7 @@ public class AdminProjectDetailResponse {
                 .id(p.getId())
                 .name(p.getName())
                 .description(p.getDescription())
+                .phase(p.getPhase().name())
                 .status(p.getStatus().name())
 
                 .startDate(p.getStartDate())

--- a/src/main/java/com/rdc/weflow_server/dto/project/response/AdminProjectSummary.java
+++ b/src/main/java/com/rdc/weflow_server/dto/project/response/AdminProjectSummary.java
@@ -1,6 +1,7 @@
 package com.rdc.weflow_server.dto.project.response;
 
 import com.rdc.weflow_server.entity.project.Project;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 public class AdminProjectSummary {
     private Long id;
     private String name;
+    private ProjectPhase phase;
     private ProjectStatus status;
     private Long customerCompanyId;
     private Long createdBy;
@@ -23,6 +25,7 @@ public class AdminProjectSummary {
         return AdminProjectSummary.builder()
                 .id(p.getId())
                 .name(p.getName())
+                .phase(p.getPhase())
                 .status(p.getStatus())
                 .customerCompanyId(p.getCompany().getId())
                 .createdBy(p.getCreatedBy())

--- a/src/main/java/com/rdc/weflow_server/dto/project/response/ProjectDetailResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/project/response/ProjectDetailResponse.java
@@ -1,6 +1,7 @@
 package com.rdc.weflow_server.dto.project.response;
 
 import com.rdc.weflow_server.entity.project.Project;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import lombok.*;
 
@@ -15,6 +16,7 @@ public class ProjectDetailResponse {
     private Long id;
     private String name;
     private String description;
+    private ProjectPhase phase;
     private ProjectStatus status;
 
     private LocalDateTime startDate;
@@ -27,6 +29,7 @@ public class ProjectDetailResponse {
                 .id(project.getId())
                 .name(project.getName())
                 .description(project.getDescription())
+                .phase(project.getPhase())
                 .status(project.getStatus())
                 .startDate(project.getStartDate())
                 .endDateExpected(project.getExpectedEndDate())

--- a/src/main/java/com/rdc/weflow_server/dto/project/response/ProjectSummaryResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/project/response/ProjectSummaryResponse.java
@@ -2,6 +2,7 @@ package com.rdc.weflow_server.dto.project.response;
 
 import com.rdc.weflow_server.entity.project.Project;
 import com.rdc.weflow_server.entity.project.ProjectMember;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectRole;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import lombok.AllArgsConstructor;
@@ -17,6 +18,7 @@ public class ProjectSummaryResponse {
 
     private Long projectId;
     private String name;
+    private ProjectPhase phase;
     private ProjectStatus status;
     private String customerCompanyName;
 
@@ -24,6 +26,7 @@ public class ProjectSummaryResponse {
         return ProjectSummaryResponse.builder()
                 .projectId(p.getId())
                 .name(p.getName())
+                .phase(p.getPhase())
                 .status(p.getStatus())
                 .customerCompanyName(p.getCompany().getName())
                 .build();

--- a/src/main/java/com/rdc/weflow_server/dto/step/StepCreateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/step/StepCreateRequest.java
@@ -1,6 +1,6 @@
 package com.rdc.weflow_server.dto.step;
 
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,5 +15,5 @@ public class StepCreateRequest {
     private String title;
     private String description;
     private Integer orderIndex;
-    private ProjectStatus phase;
+    private ProjectPhase phase;
 }

--- a/src/main/java/com/rdc/weflow_server/dto/step/StepResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/step/StepResponse.java
@@ -1,6 +1,6 @@
 package com.rdc.weflow_server.dto.step;
 
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.step.StepStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public class StepResponse {
 
     private Long id;
-    private ProjectStatus phase;
+    private ProjectPhase phase;
     private String title;
     private String description;
     private Integer orderIndex;

--- a/src/main/java/com/rdc/weflow_server/entity/post/Post.java
+++ b/src/main/java/com/rdc/weflow_server/entity/post/Post.java
@@ -1,7 +1,7 @@
 package com.rdc.weflow_server.entity.post;
 
 import com.rdc.weflow_server.entity.BaseEntity;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.step.Step;
 import com.rdc.weflow_server.entity.user.User;
 import jakarta.persistence.*;
@@ -29,7 +29,7 @@ public class Post extends BaseEntity {
     private String content; // 내용
 
     @Column
-    private ProjectStatus projectStatus; // 게시글이 어떤 phase에 속해있는지 계약-진행-납품-유지보수
+    private ProjectPhase projectPhase; // 게시글이 어떤 phase에 속해있는지 계약-진행-납품-유지보수
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false) // TODO: DELETED 없애도 될 것 같아요. 나중에 확인 @Jaehee

--- a/src/main/java/com/rdc/weflow_server/entity/project/Project.java
+++ b/src/main/java/com/rdc/weflow_server/entity/project/Project.java
@@ -32,6 +32,10 @@ public class Project extends BaseEntity {
 
     @Column(nullable = false, length = 20)
     @Enumerated(EnumType.STRING)
+    private ProjectPhase phase;
+
+    @Column(nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
     private ProjectStatus status;
 
     @Column
@@ -62,6 +66,7 @@ public class Project extends BaseEntity {
     public void updateProject(
             String name,
             String description,
+            ProjectPhase phase,
             ProjectStatus status,
             LocalDateTime startDate,
             LocalDateTime endDateExpected,
@@ -72,6 +77,7 @@ public class Project extends BaseEntity {
     ) {
         if (name != null) this.name = name;
         if (description != null) this.description = description;
+        if (phase != null) this.phase = phase;
         if (status != null) this.status = status;
         if (startDate != null) this.startDate = startDate;
         if (endDateExpected != null) this.expectedEndDate = endDateExpected;

--- a/src/main/java/com/rdc/weflow_server/entity/project/ProjectPhase.java
+++ b/src/main/java/com/rdc/weflow_server/entity/project/ProjectPhase.java
@@ -1,0 +1,5 @@
+package com.rdc.weflow_server.entity.project;
+
+public enum ProjectPhase {
+    CONTRACT, IN_PROGRESS, DELIVERY, MAINTENANCE
+}

--- a/src/main/java/com/rdc/weflow_server/entity/project/ProjectStatus.java
+++ b/src/main/java/com/rdc/weflow_server/entity/project/ProjectStatus.java
@@ -1,5 +1,5 @@
 package com.rdc.weflow_server.entity.project;
 
 public enum ProjectStatus {
-    CONTRACT, IN_PROGRESS, DELIVERY, MAINTENANCE, CLOSED
+    OPEN, CLOSED
 }

--- a/src/main/java/com/rdc/weflow_server/entity/step/Step.java
+++ b/src/main/java/com/rdc/weflow_server/entity/step/Step.java
@@ -2,7 +2,7 @@ package com.rdc.weflow_server.entity.step;
 
 import com.rdc.weflow_server.entity.BaseEntity;
 import com.rdc.weflow_server.entity.project.Project;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,7 +38,7 @@ public class Step extends BaseEntity {
 
     @Column(nullable = false, length = 20)
     @Enumerated(EnumType.STRING)
-    private ProjectStatus phase; // 상위 카테고리
+    private ProjectPhase phase; // 상위 카테고리
 
     @Column(nullable = false)
     private String title; // 단계 이름(요구사항, 기획, 디자인, 퍼블리싱, 개발 등)

--- a/src/main/java/com/rdc/weflow_server/repository/post/PostRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/post/PostRepository.java
@@ -1,7 +1,8 @@
 package com.rdc.weflow_server.repository.post;
 
 import com.rdc.weflow_server.entity.post.Post;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.post.PostOpenStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,8 +20,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 프로젝트 전체 게시글 조회
     List<Post> findByStepProjectIdAndDeletedAtIsNull(Long projectId);
 
-    // 특정 projectStatus의 게시글 조회
-    List<Post> findByStepProjectIdAndStepProjectStatusAndDeletedAtIsNull(Long projectId, ProjectStatus projectStatus);
+    // 특정 projectPhase의 게시글 조회
+    List<Post> findByStepProjectIdAndProjectPhaseAndDeletedAtIsNull(Long projectId, ProjectPhase projectPhase);
 
     // 특정 step의 게시글 조회
     List<Post> findByStepIdAndDeletedAtIsNull(Long stepId);
@@ -30,7 +31,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 페이지네이션 지원 메서드
     Page<Post> findByStepProjectIdAndDeletedAtIsNull(Long projectId, Pageable pageable);
 
-    Page<Post> findByStepProjectIdAndStepProjectStatusAndDeletedAtIsNull(Long projectId, ProjectStatus projectStatus, Pageable pageable);
+    Page<Post> findByStepProjectIdAndProjectPhaseAndDeletedAtIsNull(Long projectId, ProjectPhase projectPhase, Pageable pageable);
+
+    Page<Post> findByStepProjectIdAndProjectPhaseAndOpenStatusAndDeletedAtIsNull(Long projectId, ProjectPhase projectPhase, PostOpenStatus openStatus, Pageable pageable);
+
+    Page<Post> findByStepProjectIdAndOpenStatusAndDeletedAtIsNull(Long projectId, PostOpenStatus openStatus, Pageable pageable);
 
     Page<Post> findByStepIdAndDeletedAtIsNull(Long stepId, Pageable pageable);
+
+    Page<Post> findByStepIdAndOpenStatusAndDeletedAtIsNull(Long stepId, PostOpenStatus openStatus, Pageable pageable);
 }

--- a/src/main/java/com/rdc/weflow_server/repository/project/ProjectRepositoryCustom.java
+++ b/src/main/java/com/rdc/weflow_server/repository/project/ProjectRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.rdc.weflow_server.repository.project;
 
 import com.rdc.weflow_server.entity.project.Project;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import com.rdc.weflow_server.entity.user.UserRole;
 
@@ -8,6 +9,7 @@ import java.util.List;
 
 public interface ProjectRepositoryCustom {
     List<Project> searchAdminProjects(
+            ProjectPhase phase,
             ProjectStatus status,
             Long companyId,
             String keyword,
@@ -16,6 +18,7 @@ public interface ProjectRepositoryCustom {
     );
 
     long countAdminProjects(
+            ProjectPhase phase,
             ProjectStatus status,
             Long companyId,
             String keyword

--- a/src/main/java/com/rdc/weflow_server/repository/project/ProjectRepositoryImpl.java
+++ b/src/main/java/com/rdc/weflow_server/repository/project/ProjectRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.rdc.weflow_server.repository.project;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.rdc.weflow_server.entity.project.Project;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import com.rdc.weflow_server.entity.project.QProject;
 import com.rdc.weflow_server.entity.project.QProjectMember;
@@ -18,12 +19,13 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     private final JPAQueryFactory query;
 
     @Override
-    public List<Project> searchAdminProjects(ProjectStatus status, Long companyId, String keyword, int page, int size) {
+    public List<Project> searchAdminProjects(ProjectPhase phase, ProjectStatus status, Long companyId, String keyword, int page, int size) {
         QProject project = QProject.project;
 
         return query
                 .selectFrom(project)
                 .where(
+                        eqPhase(phase),
                         eqStatus(status),
                         eqCompany(companyId),
                         containsName(keyword)
@@ -35,13 +37,14 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     }
 
     @Override
-    public long countAdminProjects(ProjectStatus status, Long companyId, String keyword) {
+    public long countAdminProjects(ProjectPhase phase, ProjectStatus status, Long companyId, String keyword) {
         QProject project = QProject.project;
 
         return Optional.ofNullable(
                 query.select(project.count())
                         .from(project)
                         .where(
+                                eqPhase(phase),
                                 eqStatus(status),
                                 eqCompany(companyId),
                                 containsName(keyword)
@@ -91,6 +94,10 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     // ========================
     // Helper Expressions
     // ========================
+
+    private BooleanExpression eqPhase(ProjectPhase phase) {
+        return phase != null ? QProject.project.phase.eq(phase) : null;
+    }
 
     private BooleanExpression eqStatus(ProjectStatus status) {
         return status != null ? QProject.project.status.eq(status) : null;

--- a/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
@@ -1,7 +1,7 @@
 package com.rdc.weflow_server.repository.step;
 
 import com.rdc.weflow_server.entity.step.Step;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,10 +19,10 @@ public interface StepRepository extends JpaRepository<Step, Long> {
     List<Step> findByProject_IdAndDeletedAtIsNullOrderByOrderIndexAsc(Long projectId);
 
     @EntityGraph(attributePaths = {"project", "createdBy"})
-    List<Step> findByProject_IdAndPhaseAndDeletedAtIsNullOrderByOrderIndexAsc(Long projectId, ProjectStatus phase);
+    List<Step> findByProject_IdAndPhaseAndDeletedAtIsNullOrderByOrderIndexAsc(Long projectId, ProjectPhase phase);
 
     @Query("select max(s.orderIndex) from Step s where s.project.id = :projectId and s.phase = :phase and s.deletedAt is null")
-    Integer findMaxOrderIndexByProjectIdAndPhase(Long projectId, ProjectStatus phase);
+    Integer findMaxOrderIndexByProjectIdAndPhase(Long projectId, ProjectPhase phase);
 
     List<Step> findByProject_IdAndIdInAndDeletedAtIsNull(Long projectId, Collection<Long> stepIds);
 
@@ -30,7 +30,7 @@ public interface StepRepository extends JpaRepository<Step, Long> {
 
     boolean existsByProject_IdAndTitleIgnoreCaseAndIdNotAndDeletedAtIsNull(Long projectId, String title, Long id);
 
-    boolean existsByProject_IdAndPhaseAndOrderIndexAndDeletedAtIsNull(Long projectId, ProjectStatus phase, Integer orderIndex);
+    boolean existsByProject_IdAndPhaseAndOrderIndexAndDeletedAtIsNull(Long projectId, ProjectPhase phase, Integer orderIndex);
 
     Optional<Step> findByIdAndDeletedAtIsNull(Long id);
     List<Step> findByProjectIdOrderByOrderIndexAsc(Long projectId);

--- a/src/main/java/com/rdc/weflow_server/service/step/StepService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepService.java
@@ -10,8 +10,8 @@ import com.rdc.weflow_server.entity.log.ActionType;
 import com.rdc.weflow_server.entity.log.TargetTable;
 import com.rdc.weflow_server.entity.project.Project;
 import com.rdc.weflow_server.entity.project.ProjectMember;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectRole;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
 import com.rdc.weflow_server.entity.step.Step;
 import com.rdc.weflow_server.entity.step.StepStatus;
 import com.rdc.weflow_server.entity.user.User;
@@ -94,7 +94,7 @@ public class StepService {
 
     // 프로젝트 단계 목록 조회 (phase 필터)
     @Transactional(readOnly = true)
-    public StepListResponse getStepsByProject(Long projectId, ProjectStatus phase) {
+    public StepListResponse getStepsByProject(Long projectId, ProjectPhase phase) {
         List<Step> steps = stepRepository.findByProject_IdAndPhaseAndDeletedAtIsNullOrderByOrderIndexAsc(projectId, phase);
 
         List<StepResponse> stepResponses = steps.stream()
@@ -127,7 +127,7 @@ public class StepService {
             throw new BusinessException(ErrorCode.STEP_ALREADY_EXISTS);
         }
 
-        ProjectStatus phase = request.getPhase() != null ? request.getPhase() : ProjectStatus.IN_PROGRESS;
+        ProjectPhase phase = request.getPhase() != null ? request.getPhase() : ProjectPhase.IN_PROGRESS;
         Integer orderIndex = resolveOrderIndex(projectId, phase, request.getOrderIndex());
         StepStatus status = StepStatus.PENDING;
 
@@ -164,7 +164,7 @@ public class StepService {
             return;
         }
 
-        ProjectStatus phase = ProjectStatus.IN_PROGRESS;
+        ProjectPhase phase = ProjectPhase.IN_PROGRESS;
         StepStatus status = StepStatus.PENDING;
 
         List<Step> defaults = List.of(
@@ -285,7 +285,7 @@ public class StepService {
         }
 
         // phase가 섞여 있으면 순서 변경 불가
-        Set<ProjectStatus> phases = steps.stream()
+        Set<ProjectPhase> phases = steps.stream()
                 .map(Step::getPhase)
                 .collect(Collectors.toSet());
         if (phases.size() > 1) {
@@ -317,7 +317,7 @@ public class StepService {
         );
     }
 
-    private Integer resolveOrderIndex(Long projectId, ProjectStatus phase, Integer requestedOrderIndex) {
+    private Integer resolveOrderIndex(Long projectId, ProjectPhase phase, Integer requestedOrderIndex) {
         if (requestedOrderIndex == null || requestedOrderIndex < 1) {
             Integer maxOrder = stepRepository.findMaxOrderIndexByProjectIdAndPhase(projectId, phase);
             return (maxOrder == null ? 1 : maxOrder + 1);
@@ -378,7 +378,7 @@ public class StepService {
     private Step buildDefaultStep(
             Project project,
             User creator,
-            ProjectStatus phase,
+            ProjectPhase phase,
             StepStatus status,
             Integer orderIndex,
             String title

--- a/src/test/java/com/rdc/weflow_server/config/TestDataLoader.java
+++ b/src/test/java/com/rdc/weflow_server/config/TestDataLoader.java
@@ -7,6 +7,7 @@ import com.rdc.weflow_server.entity.post.Post;
 import com.rdc.weflow_server.entity.post.PostApprovalStatus;
 import com.rdc.weflow_server.entity.post.PostOpenStatus;
 import com.rdc.weflow_server.entity.project.Project;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectStatus;
 import com.rdc.weflow_server.entity.step.Step;
 import com.rdc.weflow_server.entity.step.StepStatus;
@@ -100,7 +101,8 @@ public class TestDataLoader implements CommandLineRunner {
         Project testProject = Project.builder()
                 .name("샘플 프로젝트 - 홈페이지 리뉴얼")
                 .description("테스트를 위한 샘플 프로젝트입니다")
-                .status(ProjectStatus.IN_PROGRESS)
+                .phase(ProjectPhase.IN_PROGRESS)
+                .status(ProjectStatus.OPEN)
                 .startDate(LocalDateTime.now().minusDays(30))
                 .expectedEndDate(LocalDateTime.now().plusDays(60))
                 .contractPrice(new BigDecimal("10000000"))
@@ -111,7 +113,7 @@ public class TestDataLoader implements CommandLineRunner {
 
         // 2. Step 만들기 (여러 단계)
         Step step1 = Step.builder()
-                .phase(ProjectStatus.CONTRACT)
+                .phase(ProjectPhase.CONTRACT)
                 .title("계약 및 요구사항 정의")
                 .description("프로젝트 계약 및 초기 요구사항을 정의하는 단계")
                 .orderIndex(1)
@@ -122,7 +124,7 @@ public class TestDataLoader implements CommandLineRunner {
         stepRepository.save(step1);
 
         Step step2 = Step.builder()
-                .phase(ProjectStatus.IN_PROGRESS)
+                .phase(ProjectPhase.IN_PROGRESS)
                 .title("기획 및 설계")
                 .description("화면 기획 및 시스템 설계")
                 .orderIndex(2)
@@ -133,7 +135,7 @@ public class TestDataLoader implements CommandLineRunner {
         stepRepository.save(step2);
 
         Step step3 = Step.builder()
-                .phase(ProjectStatus.IN_PROGRESS)
+                .phase(ProjectPhase.IN_PROGRESS)
                 .title("디자인")
                 .description("UI/UX 디자인 작업")
                 .orderIndex(3)
@@ -144,7 +146,7 @@ public class TestDataLoader implements CommandLineRunner {
         stepRepository.save(step3);
 
         Step step4 = Step.builder()
-                .phase(ProjectStatus.IN_PROGRESS)
+                .phase(ProjectPhase.IN_PROGRESS)
                 .title("개발")
                 .description("프론트엔드 및 백엔드 개발")
                 .orderIndex(4)
@@ -155,7 +157,7 @@ public class TestDataLoader implements CommandLineRunner {
         stepRepository.save(step4);
 
         Step step5 = Step.builder()
-                .phase(ProjectStatus.DELIVERY)
+                .phase(ProjectPhase.DELIVERY)
                 .title("테스트 및 배포")
                 .description("QA 테스트 및 운영 배포")
                 .orderIndex(5)
@@ -169,7 +171,7 @@ public class TestDataLoader implements CommandLineRunner {
         Post post1 = Post.builder()
                 .title("홈페이지 메인 페이지 레이아웃 확인 부탁드립니다")
                 .content("메인 페이지 레이아웃을 다음과 같이 구성했습니다.\n\n1. 상단 네비게이션\n2. 메인 비주얼 배너\n3. 주요 서비스 소개\n4. 최근 소식\n5. 푸터\n\n검토 후 의견 부탁드립니다.")
-                .projectStatus(ProjectStatus.IN_PROGRESS)
+                .projectPhase(ProjectPhase.IN_PROGRESS)
                 .status(PostApprovalStatus.WAITING_CONFIRM)
                 .openStatus(PostOpenStatus.OPEN)
                 .step(step2)
@@ -180,7 +182,7 @@ public class TestDataLoader implements CommandLineRunner {
         Post post2 = Post.builder()
                 .title("요구사항 정의서 최종 확정")
                 .content("고객사와 협의한 요구사항 정의서를 첨부합니다.\n\n주요 기능:\n- 회원 관리\n- 게시판\n- 예약 시스템\n- 결제 연동\n\n해당 내용으로 진행하도록 하겠습니다.")
-                .projectStatus(ProjectStatus.CONTRACT)
+                .projectPhase(ProjectPhase.CONTRACT)
                 .status(PostApprovalStatus.CONFIRMED)
                 .openStatus(PostOpenStatus.CLOSED)
                 .step(step1)
@@ -191,7 +193,7 @@ public class TestDataLoader implements CommandLineRunner {
         Post post3 = Post.builder()
                 .title("디자인 시안 공유")
                 .content("첫 번째 디자인 시안을 공유드립니다.\n\n메인 컬러는 블루 계열로 선정했으며,\n전체적으로 모던하고 깔끔한 느낌을 주도록 작업했습니다.")
-                .projectStatus(ProjectStatus.IN_PROGRESS)
+                .projectPhase(ProjectPhase.IN_PROGRESS)
                 .status(PostApprovalStatus.NORMAL)
                 .openStatus(PostOpenStatus.OPEN)
                 .step(step3)

--- a/src/test/java/com/rdc/weflow_server/controller/post/PostControllerTest.java
+++ b/src/test/java/com/rdc/weflow_server/controller/post/PostControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rdc.weflow_server.config.WithCustomMockUser;
 import com.rdc.weflow_server.dto.post.PostCreateRequest;
 import com.rdc.weflow_server.dto.post.PostUpdateRequest;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,7 +75,7 @@ class PostControllerTest {
                 "테스트 게시글 내용입니다.",
                 STEP_ID,
                 null,
-                ProjectStatus.IN_PROGRESS,
+                ProjectPhase.IN_PROGRESS,
                 null,
                 null,
                 null
@@ -128,11 +128,11 @@ class PostControllerTest {
     }
 
     @Test
-    @DisplayName("게시글 목록 조회 - projectStatus 필터")
+    @DisplayName("게시글 목록 조회 - projectPhase 필터")
     @WithCustomMockUser
-    void getPostsWithProjectStatusFilter() throws Exception {
+    void getPostsWithProjectPhaseFilter() throws Exception {
         mockMvc.perform(get("/api/projects/{projectId}/posts", PROJECT_ID)
-                        .param("projectStatus", "IN_PROGRESS")
+                        .param("projectPhase", "IN_PROGRESS")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())


### PR DESCRIPTION
  ##  Summary
  `ProjectStatus` enum을 `ProjectPhase`와 `ProjectStatus`로 분리하여 프로젝트의 페이즈(phase)와 상태(status)를 명확히 구분.

  ## 🔍 Background
  기존 `ProjectStatus` enum은 두 가지 서로 다른 개념을 혼재하여 사용하고 있었음:
  - **프로젝트 단계**: CONTRACT, IN_PROGRESS, DELIVERY, MAINTENANCE (순차적 진행 단계)
  - **프로젝트 상태**: CLOSED (프로젝트 종료 여부)

  이로 인해 다음과 같은 문제가 발생:
  - 프로젝트가 어떤 단계에 있는지와 프로젝트가 활성 상태인지를 구분할 수 없음
  - 비즈니스 로직에서 단계별 처리와 활성화 여부 처리를 명확히 분리할 수 없음
  - 필터링 시 단계와 상태를 독립적으로 조회할 수 없음

  ##  Changes

  ### 1. Core Enum 분리
  - **`ProjectPhase`** (NEW): 프로젝트 진행 단계
    - `CONTRACT`, `IN_PROGRESS`, `DELIVERY`, `MAINTENANCE`
  - **`ProjectStatus`** (REFACTORED): 프로젝트 활성화 상태
    - `OPEN`, `CLOSED`

  ### 2. Entity Layer
  - **`Project`**: `phase`와 `status` 필드 모두 보유
  - **`Step`**: `ProjectStatus` → `ProjectPhase`로 변경
  - **`Post`**: `projectStatus` → `projectPhase`로 필드명 변경

  ### 3. API Changes
  - **프로젝트 생성**: `phase`는 선택 가능 (기본값: CONTRACT), `status`는 자동으로 OPEN
  - **프로젝트 조회**: `phase`와 `status` 독립적 필터링 지원
  - **Step 조회**: `ProjectPhase` 기반 필터링
  - **Post 조회**: `projectPhase` 필터링 + `openStatus` 필터링 추가

  ### 4. DTO & Service Layer
  - 모든 Project, Step, Post 관련 DTO에서 `ProjectPhase`와 `ProjectStatus` 명확히 분리
  - Repository에서 dual filtering 지원 (phase + status)
  - Service에서 phase와 status를 독립적으로 처리

  ##  Impact
  - **Breaking Changes**: None (기존 API 호환성 유지, 필터 파라미터는 optional)
  - **Database Migration**: Required
  - `Project` 테이블에 `phase`, `status` 컬럼 추가 필요
  - `Step` 테이블의 `phase` 컬럼 타입 변경
  - `Post` 테이블의 `project_status` → `project_phase` 컬럼명 변경

