### PR TITLE
refactor : Step phase 타입 정리 및 재요청/첨부/순번 로직 보완

### DIFF
--- a/src/main/java/com/rdc/weflow_server/dto/step/StepRequestAnswerCreateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/step/StepRequestAnswerCreateRequest.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
 
 @Getter
 @NoArgsConstructor
@@ -16,5 +17,25 @@ public class StepRequestAnswerCreateRequest {
     private StepRequestAnswerType response;
     private String reasonText;
     @Size(max = 50)
-    private List<Long> attachmentIds;
+    private List<FileRequest> files;
+    @Size(max = 50)
+    private List<LinkRequest> links;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FileRequest {
+        private String fileName;
+        private Long fileSize;
+        private String filePath;
+        private String contentType;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LinkRequest {
+        @URL
+        private String url;
+    }
 }

--- a/src/main/java/com/rdc/weflow_server/dto/step/StepRequestCreateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/step/StepRequestCreateRequest.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
@@ -19,7 +18,25 @@ public class StepRequestCreateRequest {
     private String title;
     private String description;
     @Size(max = 50)
-    private List<Long> attachmentIds;
+    private List<FileRequest> files;
     @Size(max = 50)
-    private List<@URL String> links;
+    private List<LinkRequest> links;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FileRequest {
+        private String fileName;
+        private Long fileSize;
+        private String filePath;
+        private String contentType;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LinkRequest {
+        @URL
+        private String url;
+    }
 }

--- a/src/main/java/com/rdc/weflow_server/dto/step/StepRequestUpdateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/step/StepRequestUpdateRequest.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import org.hibernate.validator.constraints.URL;
 
 @Getter
 @NoArgsConstructor
@@ -18,8 +19,26 @@ public class StepRequestUpdateRequest {
     private String description;
 
     @Size(max = 50)
-    private List<Long> attachmentIds;
+    private List<FileRequest> files;
 
     @Size(max = 50)
-    private List<@URL String> links;
+    private List<LinkRequest> links;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FileRequest {
+        private String fileName;
+        private Long fileSize;
+        private String filePath;
+        private String contentType;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LinkRequest {
+        @URL
+        private String url;
+    }
 }

--- a/src/main/java/com/rdc/weflow_server/exception/ErrorCode.java
+++ b/src/main/java/com/rdc/weflow_server/exception/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
     STEP_ALREADY_EXISTS(HttpStatus.CONFLICT, "STEP_002", "이미 존재하는 단계입니다."),
     STEP_ORDER_INVALID(HttpStatus.BAD_REQUEST, "STEP_003", "단계 순서 값이 잘못되었습니다."),
     STEP_STATUS_INVALID(HttpStatus.BAD_REQUEST, "STEP_004", "단계 상태가 올바르지 않습니다."),
+    PREVIOUS_STEP_NOT_APPROVED(HttpStatus.BAD_REQUEST, "STEP_005", "이전 단계가 승인되지 않아 승인요청을 생성할 수 없습니다."),
+    INVALID_STEP_ORDER(HttpStatus.BAD_REQUEST, "STEP_006", "단계 순서 정보가 올바르지 않습니다."),
 
     // StepRequest
     STEP_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "STEP_REQUEST_001", "승인 요청을 찾을 수 없습니다."),

--- a/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
@@ -23,6 +23,8 @@ public interface StepRepository extends JpaRepository<Step, Long> {
 
     @Query("select max(s.orderIndex) from Step s where s.project.id = :projectId and s.phase = :phase and s.deletedAt is null")
     Integer findMaxOrderIndexByProjectIdAndPhase(Long projectId, ProjectStatus phase);
+    @Query("select max(s.orderIndex) from Step s where s.project.id = :projectId and s.deletedAt is null")
+    Integer findMaxOrderIndexByProjectId(Long projectId);
 
     List<Step> findByProject_IdAndIdInAndDeletedAtIsNull(Long projectId, Collection<Long> stepIds);
 
@@ -31,6 +33,7 @@ public interface StepRepository extends JpaRepository<Step, Long> {
     boolean existsByProject_IdAndTitleIgnoreCaseAndIdNotAndDeletedAtIsNull(Long projectId, String title, Long id);
 
     boolean existsByProject_IdAndPhaseAndOrderIndexAndDeletedAtIsNull(Long projectId, ProjectStatus phase, Integer orderIndex);
+    boolean existsByProject_IdAndOrderIndexAndDeletedAtIsNull(Long projectId, Integer orderIndex);
 
     Optional<Step> findByIdAndDeletedAtIsNull(Long id);
     List<Step> findByProjectIdOrderByOrderIndexAsc(Long projectId);

--- a/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
@@ -34,4 +34,5 @@ public interface StepRepository extends JpaRepository<Step, Long> {
 
     Optional<Step> findByIdAndDeletedAtIsNull(Long id);
     List<Step> findByProjectIdOrderByOrderIndexAsc(Long projectId);
+    Optional<Step> findByProject_IdAndOrderIndexAndDeletedAtIsNull(Long projectId, Integer orderIndex);
 }

--- a/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
@@ -1,7 +1,7 @@
 package com.rdc.weflow_server.repository.step;
 
 import com.rdc.weflow_server.entity.step.Step;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,10 +19,7 @@ public interface StepRepository extends JpaRepository<Step, Long> {
     List<Step> findByProject_IdAndDeletedAtIsNullOrderByOrderIndexAsc(Long projectId);
 
     @EntityGraph(attributePaths = {"project", "createdBy"})
-    List<Step> findByProject_IdAndPhaseAndDeletedAtIsNullOrderByOrderIndexAsc(Long projectId, ProjectStatus phase);
-
-    @Query("select max(s.orderIndex) from Step s where s.project.id = :projectId and s.phase = :phase and s.deletedAt is null")
-    Integer findMaxOrderIndexByProjectIdAndPhase(Long projectId, ProjectStatus phase);
+    List<Step> findByProject_IdAndPhaseAndDeletedAtIsNullOrderByOrderIndexAsc(Long projectId, ProjectPhase phase);
     @Query("select max(s.orderIndex) from Step s where s.project.id = :projectId and s.deletedAt is null")
     Integer findMaxOrderIndexByProjectId(Long projectId);
 
@@ -32,10 +29,9 @@ public interface StepRepository extends JpaRepository<Step, Long> {
 
     boolean existsByProject_IdAndTitleIgnoreCaseAndIdNotAndDeletedAtIsNull(Long projectId, String title, Long id);
 
-    boolean existsByProject_IdAndPhaseAndOrderIndexAndDeletedAtIsNull(Long projectId, ProjectStatus phase, Integer orderIndex);
     boolean existsByProject_IdAndOrderIndexAndDeletedAtIsNull(Long projectId, Integer orderIndex);
 
     Optional<Step> findByIdAndDeletedAtIsNull(Long id);
     List<Step> findByProjectIdOrderByOrderIndexAsc(Long projectId);
-    Optional<Step> findByProject_IdAndOrderIndexAndDeletedAtIsNull(Long projectId, Integer orderIndex);
+    Optional<Step> findTopByProject_IdAndOrderIndexAndDeletedAtIsNullOrderByIdAsc(Long projectId, Integer orderIndex);
 }

--- a/src/main/java/com/rdc/weflow_server/repository/step/StepRequestRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/step/StepRequestRepository.java
@@ -53,5 +53,6 @@ public interface StepRequestRepository extends JpaRepository<StepRequest, Long> 
             Long projectId,
             StepRequestStatus status
     );
+    boolean existsByStep_IdAndStatusIn(Long stepId, List<StepRequestStatus> statuses);
 
 }

--- a/src/main/java/com/rdc/weflow_server/service/step/StepRequestAnswerService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepRequestAnswerService.java
@@ -10,7 +10,6 @@ import com.rdc.weflow_server.entity.step.StepRequestAnswer;
 import com.rdc.weflow_server.entity.step.StepRequestAnswerType;
 import com.rdc.weflow_server.entity.step.StepRequestHistory;
 import com.rdc.weflow_server.entity.step.StepRequestStatus;
-import com.rdc.weflow_server.entity.step.StepStatus;
 import com.rdc.weflow_server.entity.user.User;
 import com.rdc.weflow_server.entity.user.UserRole;
 import com.rdc.weflow_server.exception.BusinessException;
@@ -96,11 +95,7 @@ public class StepRequestAnswerService {
         stepRequest.updateDecidedAt(LocalDateTime.now());
         stepRequest.updateDecidedBy(user);
 
-        if (newStatus == StepRequestStatus.APPROVED) {
-            stepRequest.getStep().updateStatus(StepStatus.APPROVED);
-        } else {
-            stepRequestService.refreshStepStatus(stepRequest.getStep());
-        }
+        stepRequestService.updateStepStatusBasedOnRequests(stepRequest.getStep());
 
         StepRequestAnswer saved = stepRequestAnswerRepository.save(answer);
         // REASON_UPDATE: 반려/승인 사유 afterContent 기록

--- a/src/main/java/com/rdc/weflow_server/service/step/StepRequestAnswerService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepRequestAnswerService.java
@@ -1,7 +1,9 @@
 package com.rdc.weflow_server.service.step;
 
+import com.rdc.weflow_server.dto.attachment.AttachmentSimpleResponse;
 import com.rdc.weflow_server.dto.step.StepRequestAnswerCreateRequest;
 import com.rdc.weflow_server.dto.step.StepRequestAnswerResponse;
+import com.rdc.weflow_server.entity.attachment.Attachment;
 import com.rdc.weflow_server.entity.log.ActionType;
 import com.rdc.weflow_server.entity.log.TargetTable;
 import com.rdc.weflow_server.entity.notification.NotificationType;
@@ -14,6 +16,7 @@ import com.rdc.weflow_server.entity.user.User;
 import com.rdc.weflow_server.entity.user.UserRole;
 import com.rdc.weflow_server.exception.BusinessException;
 import com.rdc.weflow_server.exception.ErrorCode;
+import com.rdc.weflow_server.repository.attachment.AttachmentRepository;
 import com.rdc.weflow_server.repository.project.ProjectMemberRepository;
 import com.rdc.weflow_server.repository.step.StepRequestAnswerRepository;
 import com.rdc.weflow_server.repository.step.StepRequestHistoryRepository;
@@ -21,12 +24,14 @@ import com.rdc.weflow_server.repository.step.StepRequestRepository;
 import com.rdc.weflow_server.repository.user.UserRepository;
 import com.rdc.weflow_server.service.log.ActivityLogService;
 import com.rdc.weflow_server.service.log.AuditContext;
+import com.rdc.weflow_server.service.file.S3FileService;
 import com.rdc.weflow_server.service.notification.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -36,11 +41,13 @@ public class StepRequestAnswerService {
     private final StepRequestRepository stepRequestRepository;
     private final StepRequestAnswerRepository stepRequestAnswerRepository;
     private final StepRequestHistoryRepository stepRequestHistoryRepository;
+    private final AttachmentRepository attachmentRepository;
     private final UserRepository userRepository;
     private final ProjectMemberRepository projectMemberRepository;
     private final StepRequestService stepRequestService;
     private final ActivityLogService activityLogService;
     private final NotificationService notificationService;
+    private final S3FileService s3FileService;
 
     public StepRequestAnswerResponse answerRequest(Long requestId, AuditContext ctx, StepRequestAnswerCreateRequest request) {
         StepRequest stepRequest = stepRequestRepository.findById(requestId)
@@ -80,8 +87,7 @@ public class StepRequestAnswerService {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        stepRequestAnswerRepository.findByStepRequest_Id(requestId)
-                .ifPresent(existing -> { throw new BusinessException(ErrorCode.STEP_ANSWER_ALREADY_EXISTS); });
+        clearExistingAnswer(requestId);
 
         StepRequestStatus newStatus = mapAnswerToStatus(request.getResponse());
         StepRequestAnswer answer = StepRequestAnswer.builder()
@@ -98,6 +104,8 @@ public class StepRequestAnswerService {
         stepRequestService.updateStepStatusBasedOnRequests(stepRequest.getStep());
 
         StepRequestAnswer saved = stepRequestAnswerRepository.save(answer);
+        syncAnswerFiles(saved, toFilePayloads(request.getFiles()));
+        syncAnswerLinks(saved, toLinkPayloads(request.getLinks()));
         // REASON_UPDATE: 반려/승인 사유 afterContent 기록
         saveReasonHistory(stepRequest, request.getReasonText(), user);
         activityLogService.createLog(
@@ -131,6 +139,7 @@ public class StepRequestAnswerService {
                 .respondedBy(answer.getRespondedBy() != null ? answer.getRespondedBy().getId() : null)
                 .respondedByName(answer.getRespondedBy() != null ? answer.getRespondedBy().getName() : null)
                 .reasonText(answer.getReasonText())
+                .attachments(getAttachments(answer))
                 .decidedAt(answer.getStepRequest() != null ? answer.getStepRequest().getDecidedAt() : null)
                 .createdAt(answer.getCreatedAt())
                 .build();
@@ -168,6 +177,134 @@ public class StepRequestAnswerService {
                 .updatedBy(updatedBy)
                 .build();
         stepRequestHistoryRepository.save(history);
+    }
+
+    private void syncAnswerFiles(StepRequestAnswer answer, List<SimpleFilePayload> files) {
+        if (files == null) {
+            return;
+        }
+
+        attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentType(
+                Attachment.TargetType.STEP_REQUEST_ANSWER,
+                answer.getId(),
+                Attachment.AttachmentType.FILE
+        );
+
+        if (files.isEmpty()) {
+            return;
+        }
+
+        for (SimpleFilePayload file : files) {
+            validateFilePayload(file);
+            Attachment attachment = Attachment.builder()
+                    .targetType(Attachment.TargetType.STEP_REQUEST_ANSWER)
+                    .targetId(answer.getId())
+                    .attachmentType(Attachment.AttachmentType.FILE)
+                    .fileName(file.fileName())
+                    .fileSize(file.fileSize())
+                    .filePath(file.filePath())
+                    .contentType(file.contentType())
+                    .build();
+            attachmentRepository.save(attachment);
+        }
+    }
+
+    private void syncAnswerLinks(StepRequestAnswer answer, List<SimpleLinkPayload> links) {
+        if (links == null) {
+            return;
+        }
+
+        attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentType(
+                Attachment.TargetType.STEP_REQUEST_ANSWER,
+                answer.getId(),
+                Attachment.AttachmentType.LINK
+        );
+
+        if (links.isEmpty()) {
+            return;
+        }
+
+        for (SimpleLinkPayload link : links) {
+            validateLinkPayload(link);
+            Attachment attachment = Attachment.builder()
+                    .targetType(Attachment.TargetType.STEP_REQUEST_ANSWER)
+                    .targetId(answer.getId())
+                    .attachmentType(Attachment.AttachmentType.LINK)
+                    .url(link.url())
+                    .build();
+            attachmentRepository.save(attachment);
+        }
+    }
+
+    private List<AttachmentSimpleResponse> getAttachments(StepRequestAnswer answer) {
+        List<Attachment> attachments = attachmentRepository.findByTargetTypeAndTargetId(
+                Attachment.TargetType.STEP_REQUEST_ANSWER,
+                answer.getId()
+        );
+        return attachments.stream()
+                .map(this::toAttachmentSimpleResponse)
+                .toList();
+    }
+
+    private AttachmentSimpleResponse toAttachmentSimpleResponse(Attachment attachment) {
+        String url = attachment.getAttachmentType() == Attachment.AttachmentType.FILE && attachment.getFilePath() != null
+                ? s3FileService.generateDownloadPresignedUrl(attachment.getFilePath(), attachment.getFileName())
+                : attachment.getUrl();
+        return AttachmentSimpleResponse.from(attachment, url);
+    }
+
+    private List<SimpleFilePayload> toFilePayloads(List<StepRequestAnswerCreateRequest.FileRequest> files) {
+        if (files == null) {
+            return null;
+        }
+        return files.stream()
+                .map(f -> new SimpleFilePayload(f.getFileName(), f.getFileSize(), f.getFilePath(), f.getContentType()))
+                .toList();
+    }
+
+    private List<SimpleLinkPayload> toLinkPayloads(List<StepRequestAnswerCreateRequest.LinkRequest> links) {
+        if (links == null) {
+            return null;
+        }
+        return links.stream()
+                .map(l -> new SimpleLinkPayload(l.getUrl()))
+                .toList();
+    }
+
+    private record SimpleFilePayload(String fileName, Long fileSize, String filePath, String contentType) {}
+
+    private record SimpleLinkPayload(String url) {}
+
+    private void validateFilePayload(SimpleFilePayload file) {
+        if (file == null || file.filePath() == null || file.filePath().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (file.filePath().startsWith("http://") || file.filePath().startsWith("https://")) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (file.filePath().length() > 500) { // DB 컬럼 길이
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateLinkPayload(SimpleLinkPayload link) {
+        if (link == null || link.url() == null || link.url().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (!(link.url().startsWith("http://") || link.url().startsWith("https://"))) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void clearExistingAnswer(Long requestId) {
+        stepRequestAnswerRepository.findByStepRequest_Id(requestId)
+                .ifPresent(existing -> {
+                    attachmentRepository.deleteByTargetTypeAndTargetId(
+                            Attachment.TargetType.STEP_REQUEST_ANSWER,
+                            existing.getId()
+                    );
+                    stepRequestAnswerRepository.delete(existing);
+                });
     }
 
     private void notifyRequesterDecision(StepRequest stepRequest, StepRequestAnswer answer) {

--- a/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
@@ -497,7 +497,7 @@ public class StepRequestService {
             return; // 첫 단계는 예외
         }
 
-        Step previousStep = stepRepository.findByProject_IdAndOrderIndexAndDeletedAtIsNull(
+        Step previousStep = stepRepository.findTopByProject_IdAndOrderIndexAndDeletedAtIsNullOrderByIdAsc(
                         step.getProject().getId(),
                         orderIndex - 1)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_STEP_ORDER));

--- a/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
@@ -509,20 +509,7 @@ public class StepRequestService {
     }
 
     public void refreshStepStatus(Step step) {
-        if (step == null) {
-            return;
-        }
-
-        if (step.getStatus() == StepStatus.APPROVED) {
-            return;
-        }
-
-        boolean hasRequested = stepRequestRepository.existsByStep_IdAndStatus(step.getId(), StepRequestStatus.REQUESTED);
-        if (hasRequested) {
-            step.updateStatus(StepStatus.WAITING_APPROVAL);
-        } else {
-            step.updateStatus(StepStatus.PENDING);
-        }
+        updateStepStatusBasedOnRequests(step);
     }
 
     private void validatePreviousStepApproved(Step step) {
@@ -543,6 +530,31 @@ public class StepRequestService {
         if (previousStep.getStatus() != StepStatus.APPROVED) {
             throw new BusinessException(ErrorCode.PREVIOUS_STEP_NOT_APPROVED);
         }
+    }
+
+    public void updateStepStatusBasedOnRequests(Step step) {
+        if (step == null || step.getId() == null) {
+            return;
+        }
+
+        List<StepRequestStatus> inProgressStatuses = List.of(
+                StepRequestStatus.REQUESTED,
+                StepRequestStatus.CHANGE_REQUESTED
+        );
+
+        boolean hasInProgress = stepRequestRepository.existsByStep_IdAndStatusIn(step.getId(), inProgressStatuses);
+        if (hasInProgress) {
+            step.updateStatus(StepStatus.WAITING_APPROVAL);
+            return;
+        }
+
+        boolean hasApproved = stepRequestRepository.existsByStep_IdAndStatus(step.getId(), StepRequestStatus.APPROVED);
+        if (hasApproved) {
+            step.updateStatus(StepStatus.APPROVED);
+            return;
+        }
+
+        step.updateStatus(StepStatus.PENDING);
     }
 
     private String toRequestContent(StepRequestCreateRequest request) {

--- a/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
@@ -24,6 +24,7 @@ import com.rdc.weflow_server.service.notification.NotificationService;
 import com.rdc.weflow_server.repository.attachment.AttachmentRepository;
 import com.rdc.weflow_server.repository.project.ProjectMemberRepository;
 import com.rdc.weflow_server.repository.step.StepRequestHistoryRepository;
+import com.rdc.weflow_server.repository.step.StepRequestAnswerRepository;
 import com.rdc.weflow_server.repository.step.StepRequestRepository;
 import com.rdc.weflow_server.repository.step.StepRepository;
 import com.rdc.weflow_server.repository.user.UserRepository;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +57,7 @@ public class StepRequestService {
     private final S3FileService s3FileService;
     private final NotificationService notificationService;
     private final StepRepository stepRepository;
+    private final StepRequestAnswerRepository stepRequestAnswerRepository;
 
     public StepRequestResponse createRequest(Long stepId, AuditContext ctx, StepRequestCreateRequest request) {
         Step step = stepService.getStepOrThrow(stepId);
@@ -93,8 +96,8 @@ public class StepRequestService {
                 .build();
 
         StepRequest saved = stepRequestRepository.save(stepRequest);
-        attachFiles(saved, request.getAttachmentIds(), ctx);
-        attachLinks(saved, request.getLinks(), ctx);
+        syncRequestFiles(saved, toFilePayloads(request.getFiles()), ctx);
+        syncRequestLinks(saved, toLinkPayloads(request.getLinks()), ctx);
 
         // 단계 상태를 승인 대기로 변경 (기존이 아니면)
         if (step.getStatus() != StepStatus.WAITING_APPROVAL) {
@@ -157,13 +160,22 @@ public class StepRequestService {
         }
 
         // 파일 첨부 동기화 (null이면 유지, 빈 리스트면 모두 제거)
-        if (request.getAttachmentIds() != null) {
-            replaceFiles(stepRequest, request.getAttachmentIds(), ctx);
+        if (request.getFiles() != null) {
+            syncRequestFiles(stepRequest, toFilePayloads(request.getFiles()), ctx);
         }
 
         // 링크 첨부 동기화 (null이면 유지, 빈 리스트면 모두 제거)
         if (request.getLinks() != null) {
-            replaceLinks(stepRequest, request.getLinks(), ctx);
+            syncRequestLinks(stepRequest, toLinkPayloads(request.getLinks()), ctx);
+        }
+
+        // CHANGE_REQUESTED -> REQUESTED 재요청 전이
+        if (stepRequest.getStatus() == StepRequestStatus.CHANGE_REQUESTED) {
+            clearExistingAnswer(stepRequest);
+            stepRequest.updateStatus(StepRequestStatus.REQUESTED);
+            stepRequest.updateDecidedAt(null);
+            stepRequest.updateDecidedBy(null);
+            saveHistory(stepRequest, HistoryType.REQUEST_UPDATE, "status", StepRequestStatus.CHANGE_REQUESTED.name(), StepRequestStatus.REQUESTED.name(), user);
         }
 
         // 수정 이력 기록
@@ -177,6 +189,7 @@ public class StepRequestService {
                 step.getProject().getId(),
                 ctx.ipAddress()
         );
+        updateStepStatusBasedOnRequests(step);
         notifyClients(stepRequest, NotificationType.STEP_REQUEST, step.getTitle(), stepRequest.getRequestTitle());
         return toResponse(stepRequest);
     }
@@ -283,76 +296,31 @@ public class StepRequestService {
         notifyClients(stepRequest, NotificationType.STEP_REQUEST, step.getTitle(), "승인 요청이 취소되었습니다.");
     }
 
-    private void attachFiles(StepRequest stepRequest, List<Long> attachmentIds, AuditContext ctx) {
-        if (attachmentIds == null || attachmentIds.isEmpty()) {
+    private void syncRequestFiles(StepRequest stepRequest, List<SimpleFilePayload> files, AuditContext ctx) {
+        if (files == null) {
             return;
         }
 
-        List<Attachment> attachments = attachmentRepository.findAllById(attachmentIds);
-        if (attachments.size() != attachmentIds.size()) {
-            throw new BusinessException(ErrorCode.ATTACHMENT_NOT_FOUND);
-        }
+        attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentType(
+                Attachment.TargetType.STEP_REQUEST,
+                stepRequest.getId(),
+                Attachment.AttachmentType.FILE
+        );
 
-        for (Attachment attachment : attachments) {
-            if (attachment.getTargetType() != Attachment.TargetType.STEP_REQUEST) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-            }
-            if (attachment.getTargetId() != null && !attachment.getTargetId().equals(stepRequest.getId())) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-            }
-            attachment.bindTo(Attachment.TargetType.STEP_REQUEST, stepRequest.getId());
-            activityLogService.createLog(
-                    ActionType.UPLOAD,
-                    TargetTable.ATTACHMENT,
-                    attachment.getId(),
-                    ctx.userId(),
-                    stepRequest.getStep().getProject().getId(),
-                    ctx.ipAddress()
-            );
-        }
-    }
-
-    private void attachLinks(StepRequest stepRequest, List<String> links, AuditContext ctx) {
-        if (links == null) {
-            return;
-        }
-        if (links.isEmpty()) {
-        List<Attachment> existingLinks = attachmentRepository.findByTargetTypeAndTargetId(
-                        Attachment.TargetType.STEP_REQUEST,
-                        stepRequest.getId())
-                .stream()
-                .filter(a -> a.getAttachmentType() == Attachment.AttachmentType.LINK)
-                .toList();
-        if (!existingLinks.isEmpty()) {
-            attachmentRepository.deleteAll(existingLinks);
-            for (Attachment link : existingLinks) {
-                activityLogService.createLog(
-                        ActionType.REMOVE,
-                        TargetTable.ATTACHMENT,
-                        link.getId(),
-                        ctx.userId(),
-                        stepRequest.getStep().getProject().getId(),
-                        ctx.ipAddress()
-                );
-            }
-            activityLogService.createLog(
-                    ActionType.REMOVE,
-                    TargetTable.STEP_REQUEST,
-                    stepRequest.getId(),
-                    ctx.userId(),
-                    stepRequest.getStep().getProject().getId(),
-                    ctx.ipAddress()
-            );
-        }
+        if (files.isEmpty()) {
             return;
         }
 
-        for (String link : links) {
+        for (SimpleFilePayload file : files) {
+            validateFilePayload(file);
             Attachment attachment = Attachment.builder()
                     .targetType(Attachment.TargetType.STEP_REQUEST)
                     .targetId(stepRequest.getId())
-                    .attachmentType(Attachment.AttachmentType.LINK)
-                    .url(link)
+                    .attachmentType(Attachment.AttachmentType.FILE)
+                    .fileName(file.fileName())
+                    .fileSize(file.fileSize())
+                    .filePath(file.filePath())
+                    .contentType(file.contentType())
                     .build();
             attachmentRepository.save(attachment);
             activityLogService.createLog(
@@ -366,32 +334,39 @@ public class StepRequestService {
         }
     }
 
-    private void replaceFiles(StepRequest stepRequest, List<Long> incomingIds, AuditContext ctx) {
-        List<Attachment> existing = attachmentRepository.findByTargetTypeAndTargetId(Attachment.TargetType.STEP_REQUEST, stepRequest.getId())
-                .stream()
-                .filter(a -> a.getAttachmentType() == Attachment.AttachmentType.FILE)
-                .collect(Collectors.toList());
+    private void syncRequestLinks(StepRequest stepRequest, List<SimpleLinkPayload> links, AuditContext ctx) {
+        if (links == null) {
+            return;
+        }
 
-        // 제거 대상: 기존 파일 중 incomingIds에 없는 것들
-        existing.stream()
-                .filter(a -> !incomingIds.contains(a.getId()))
-                .forEach(a -> {
-                    attachmentRepository.delete(a);
-                    activityLogService.createLog(
-                            ActionType.REMOVE,
-                            TargetTable.ATTACHMENT,
-                            a.getId(),
-                            ctx.userId(),
-                            stepRequest.getStep().getProject().getId(),
-                            ctx.ipAddress()
-                    );
-                });
+        attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentType(
+                Attachment.TargetType.STEP_REQUEST,
+                stepRequest.getId(),
+                Attachment.AttachmentType.LINK
+        );
 
-        attachFiles(stepRequest, incomingIds, ctx);
-    }
+        if (links.isEmpty()) {
+            return;
+        }
 
-    private void replaceLinks(StepRequest stepRequest, List<String> links, AuditContext ctx) {
-        attachLinks(stepRequest, links, ctx);
+        for (SimpleLinkPayload link : links) {
+            validateLinkPayload(link);
+            Attachment attachment = Attachment.builder()
+                    .targetType(Attachment.TargetType.STEP_REQUEST)
+                    .targetId(stepRequest.getId())
+                    .attachmentType(Attachment.AttachmentType.LINK)
+                    .url(link.url())
+                    .build();
+            attachmentRepository.save(attachment);
+            activityLogService.createLog(
+                    ActionType.UPLOAD,
+                    TargetTable.ATTACHMENT,
+                    attachment.getId(),
+                    ctx.userId(),
+                    stepRequest.getStep().getProject().getId(),
+                    ctx.ipAddress()
+            );
+        }
     }
 
     private StepRequestResponse toResponse(StepRequest stepRequest) {
@@ -557,6 +532,66 @@ public class StepRequestService {
         step.updateStatus(StepStatus.PENDING);
     }
 
+    private List<SimpleFilePayload> toFilePayloads(List<?> files) {
+        if (files == null) {
+            return null;
+        }
+        return files.stream()
+                .flatMap(f -> {
+                    if (f instanceof StepRequestCreateRequest.FileRequest fr) {
+                        return Stream.of(new SimpleFilePayload(fr.getFileName(), fr.getFileSize(), fr.getFilePath(), fr.getContentType()));
+                    }
+                    if (f instanceof StepRequestUpdateRequest.FileRequest fr) {
+                        return Stream.of(new SimpleFilePayload(fr.getFileName(), fr.getFileSize(), fr.getFilePath(), fr.getContentType()));
+                    }
+                    return Stream.empty();
+                })
+                .toList();
+    }
+
+    private List<SimpleLinkPayload> toLinkPayloads(List<?> links) {
+        if (links == null) {
+            return null;
+        }
+        return links.stream()
+                .flatMap(l -> {
+                    if (l instanceof StepRequestCreateRequest.LinkRequest lr) {
+                        return Stream.of(new SimpleLinkPayload(lr.getUrl()));
+                    }
+                    if (l instanceof StepRequestUpdateRequest.LinkRequest lr) {
+                        return Stream.of(new SimpleLinkPayload(lr.getUrl()));
+                    }
+                    return Stream.empty();
+                })
+                .toList();
+    }
+
+    private record SimpleFilePayload(String fileName, Long fileSize, String filePath, String contentType) {}
+
+    private record SimpleLinkPayload(String url) {}
+
+    private void validateFilePayload(SimpleFilePayload file) {
+        if (file == null || file.filePath() == null || file.filePath().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (file.filePath().startsWith("http://") || file.filePath().startsWith("https://")) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        // DB 컬럼 길이 고려
+        if (file.filePath().length() > 500) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateLinkPayload(SimpleLinkPayload link) {
+        if (link == null || link.url() == null || link.url().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (!(link.url().startsWith("http://") || link.url().startsWith("https://"))) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
     private String toRequestContent(StepRequestCreateRequest request) {
         // 단순 문자열 직렬화 (추후 JSON 포맷 필요 시 교체)
         return String.format("title=%s;description=%s", request.getTitle(), request.getDescription());
@@ -564,5 +599,20 @@ public class StepRequestService {
 
     private String toRequestContent(String title, String description) {
         return String.format("title=%s;description=%s", title, description);
+    }
+
+    private void clearExistingAnswer(StepRequest stepRequest) {
+        if (stepRequest == null || stepRequest.getId() == null) {
+            return;
+        }
+
+        stepRequestAnswerRepository.findByStepRequest_Id(stepRequest.getId())
+                .ifPresent(answer -> {
+                    attachmentRepository.deleteByTargetTypeAndTargetId(
+                            Attachment.TargetType.STEP_REQUEST_ANSWER,
+                            answer.getId()
+                    );
+                    stepRequestAnswerRepository.delete(answer);
+                });
     }
 }

--- a/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
@@ -25,6 +25,7 @@ import com.rdc.weflow_server.repository.attachment.AttachmentRepository;
 import com.rdc.weflow_server.repository.project.ProjectMemberRepository;
 import com.rdc.weflow_server.repository.step.StepRequestHistoryRepository;
 import com.rdc.weflow_server.repository.step.StepRequestRepository;
+import com.rdc.weflow_server.repository.step.StepRepository;
 import com.rdc.weflow_server.repository.user.UserRepository;
 import com.rdc.weflow_server.service.log.ActivityLogService;
 import com.rdc.weflow_server.service.file.S3FileService;
@@ -53,6 +54,7 @@ public class StepRequestService {
     private final ActivityLogService activityLogService;
     private final S3FileService s3FileService;
     private final NotificationService notificationService;
+    private final StepRepository stepRepository;
 
     public StepRequestResponse createRequest(Long stepId, AuditContext ctx, StepRequestCreateRequest request) {
         Step step = stepService.getStepOrThrow(stepId);
@@ -79,6 +81,8 @@ public class StepRequestService {
         if (step.getStatus() == StepStatus.APPROVED) {
             throw new BusinessException(ErrorCode.STEP_STATUS_INVALID);
         }
+
+        validatePreviousStepApproved(step);
 
         StepRequest stepRequest = StepRequest.builder()
                 .requestTitle(request.getTitle())
@@ -518,6 +522,26 @@ public class StepRequestService {
             step.updateStatus(StepStatus.WAITING_APPROVAL);
         } else {
             step.updateStatus(StepStatus.PENDING);
+        }
+    }
+
+    private void validatePreviousStepApproved(Step step) {
+        if (step == null || step.getProject() == null || step.getOrderIndex() == null) {
+            throw new BusinessException(ErrorCode.INVALID_STEP_ORDER);
+        }
+
+        Integer orderIndex = step.getOrderIndex();
+        if (orderIndex <= 1) {
+            return; // 첫 단계는 예외
+        }
+
+        Step previousStep = stepRepository.findByProject_IdAndOrderIndexAndDeletedAtIsNull(
+                        step.getProject().getId(),
+                        orderIndex - 1)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_STEP_ORDER));
+
+        if (previousStep.getStatus() != StepStatus.APPROVED) {
+            throw new BusinessException(ErrorCode.PREVIOUS_STEP_NOT_APPROVED);
         }
     }
 

--- a/src/main/java/com/rdc/weflow_server/service/step/StepService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepService.java
@@ -10,8 +10,8 @@ import com.rdc.weflow_server.entity.log.ActionType;
 import com.rdc.weflow_server.entity.log.TargetTable;
 import com.rdc.weflow_server.entity.project.Project;
 import com.rdc.weflow_server.entity.project.ProjectMember;
+import com.rdc.weflow_server.entity.project.ProjectPhase;
 import com.rdc.weflow_server.entity.project.ProjectRole;
-import com.rdc.weflow_server.entity.project.ProjectStatus;
 import com.rdc.weflow_server.entity.step.Step;
 import com.rdc.weflow_server.entity.step.StepStatus;
 import com.rdc.weflow_server.entity.user.User;
@@ -94,7 +94,7 @@ public class StepService {
 
     // 프로젝트 단계 목록 조회 (phase 필터)
     @Transactional(readOnly = true)
-    public StepListResponse getStepsByProject(Long projectId, ProjectStatus phase) {
+    public StepListResponse getStepsByProject(Long projectId, ProjectPhase phase) {
         List<Step> steps = stepRepository.findByProject_IdAndPhaseAndDeletedAtIsNullOrderByOrderIndexAsc(projectId, phase);
 
         List<StepResponse> stepResponses = steps.stream()
@@ -127,7 +127,7 @@ public class StepService {
             throw new BusinessException(ErrorCode.STEP_ALREADY_EXISTS);
         }
 
-        ProjectStatus phase = request.getPhase() != null ? request.getPhase() : ProjectStatus.IN_PROGRESS;
+        ProjectPhase phase = request.getPhase() != null ? request.getPhase() : ProjectPhase.IN_PROGRESS;
         Integer orderIndex = resolveOrderIndex(projectId, request.getOrderIndex());
         StepStatus status = StepStatus.PENDING;
 
@@ -164,7 +164,7 @@ public class StepService {
             return;
         }
 
-        ProjectStatus phase = ProjectStatus.IN_PROGRESS;
+        ProjectPhase phase = ProjectPhase.IN_PROGRESS;
         StepStatus status = StepStatus.PENDING;
 
         List<Step> defaults = List.of(
@@ -285,7 +285,7 @@ public class StepService {
         }
 
         // phase가 섞여 있으면 순서 변경 불가
-        Set<ProjectStatus> phases = steps.stream()
+        Set<ProjectPhase> phases = steps.stream()
                 .map(Step::getPhase)
                 .collect(Collectors.toSet());
         if (phases.size() > 1) {
@@ -378,7 +378,7 @@ public class StepService {
     private Step buildDefaultStep(
             Project project,
             User creator,
-            ProjectStatus phase,
+            ProjectPhase phase,
             StepStatus status,
             Integer orderIndex,
             String title

--- a/src/main/java/com/rdc/weflow_server/service/step/StepService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepService.java
@@ -128,7 +128,7 @@ public class StepService {
         }
 
         ProjectStatus phase = request.getPhase() != null ? request.getPhase() : ProjectStatus.IN_PROGRESS;
-        Integer orderIndex = resolveOrderIndex(projectId, phase, request.getOrderIndex());
+        Integer orderIndex = resolveOrderIndex(projectId, request.getOrderIndex());
         StepStatus status = StepStatus.PENDING;
 
         Step step = Step.builder()
@@ -317,12 +317,12 @@ public class StepService {
         );
     }
 
-    private Integer resolveOrderIndex(Long projectId, ProjectStatus phase, Integer requestedOrderIndex) {
+    private Integer resolveOrderIndex(Long projectId, Integer requestedOrderIndex) {
         if (requestedOrderIndex == null || requestedOrderIndex < 1) {
-            Integer maxOrder = stepRepository.findMaxOrderIndexByProjectIdAndPhase(projectId, phase);
+            Integer maxOrder = stepRepository.findMaxOrderIndexByProjectId(projectId);
             return (maxOrder == null ? 1 : maxOrder + 1);
         }
-        if (stepRepository.existsByProject_IdAndPhaseAndOrderIndexAndDeletedAtIsNull(projectId, phase, requestedOrderIndex)) {
+        if (stepRepository.existsByProject_IdAndOrderIndexAndDeletedAtIsNull(projectId, requestedOrderIndex)) {
             throw new BusinessException(ErrorCode.STEP_ORDER_INVALID);
         }
         return requestedOrderIndex;


### PR DESCRIPTION

  - StepRequest 재요청 플로우 수정: CHANGE_REQUESTED→REQUESTED 시 기존 답변/첨부 제거, 상태/결정자 초기화 후 다시 승인/반려 가능하도록 처리.
  - StepRequestAnswer 생성 시 기존 답변이 있으면 첨부 포함 삭제 후 새 답변 저장(“이미 답변됨” 오류 방지).
  - 첨부 분류/검증 정리: 링크를 파일로 보내는 오류를 차단하고 filePath/url 유효성 보강.
  - 단계 orderIndex 기본값을 프로젝트 단위 max+1로 통일(phase 무관), 중복 orderIndex 조회 시 단건만 참조하도록 개선.
  - Step.phase 타입을 ProjectPhase로 통일(엔티티/서비스/DTO/컨트롤러/리포지토리).