### PR TITLE
refactor(post): 질문-답변 시스템을 객관식/주관식 설문 형식으로 개선

### DIFF
--- a/src/main/java/com/rdc/weflow_server/dto/post/PostAnswerRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostAnswerRequest.java
@@ -1,16 +1,17 @@
 package com.rdc.weflow_server.dto.post;
 
-import com.rdc.weflow_server.entity.post.AnswerType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostAnswerRequest {
 
-    private AnswerType answerType;
-    private String content;  // 사유/의견 (선택사항)
+    private List<Long> selectedOptionIds;  // 선택된 옵션 ID들 (객관식, 복수선택)
+    private String textInput;              // 주관식 답변 또는 기타 입력
 
 }

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostCreateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostCreateRequest.java
@@ -43,7 +43,15 @@ public class PostCreateRequest {
     @AllArgsConstructor
     public static class QuestionRequest {
         private String questionText;
-        private String confirmLabel;
-        private String rejectLabel;
+        private String questionType; // SINGLE, MULTI, TEXT
+        private List<QuestionOptionRequest> options;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionOptionRequest {
+        private String optionText;
+        private Boolean hasInput;
     }
 }

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostDetailResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostDetailResponse.java
@@ -81,7 +81,8 @@ public class PostDetailResponse {
     public static class QuestionDto {
         private Long questionId;
         private String content;
-        private ButtonLabelsDto buttonLabels;
+        private String questionType; // SINGLE, MULTI, TEXT
+        private List<QuestionOptionDto> options;
         private AnswerDto answer;
     }
 
@@ -89,9 +90,10 @@ public class PostDetailResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ButtonLabelsDto {
-        private String yes;
-        private String no;
+    public static class QuestionOptionDto {
+        private Long optionId;
+        private String optionText;
+        private Boolean hasInput;
     }
 
     @Getter
@@ -99,7 +101,8 @@ public class PostDetailResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AnswerDto {
-        private String response;
+        private List<Long> selectedOptionIds;
+        private String textInput;
         private RespondentDto respondent;
         private LocalDateTime respondedAt;
     }

--- a/src/main/java/com/rdc/weflow_server/dto/post/PostUpdateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostUpdateRequest.java
@@ -39,7 +39,15 @@ public class PostUpdateRequest {
     @AllArgsConstructor
     public static class QuestionRequest {
         private String questionText;
-        private String confirmLabel;
-        private String rejectLabel;
+        private String questionType; // SINGLE, MULTI, TEXT
+        private List<QuestionOptionRequest> options;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionOptionRequest {
+        private String optionText;
+        private Boolean hasInput;
     }
 }

--- a/src/main/java/com/rdc/weflow_server/entity/post/PostQuestion.java
+++ b/src/main/java/com/rdc/weflow_server/entity/post/PostQuestion.java
@@ -4,6 +4,9 @@ import com.rdc.weflow_server.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -23,10 +26,12 @@ public class PostQuestion extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String questionText; // 질문 내용
 
-    @Column(length = 50)
-    private String confirmLabel; // 확인 버튼 라벨
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private QuestionType questionType; // 질문 타입 (SINGLE, MULTI, TEXT)
 
-    @Column(length = 50)
-    private String rejectLabel; // 거절 버튼 라벨
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<PostQuestionOption> options = new ArrayList<>(); // 질문 옵션들
 
 }

--- a/src/main/java/com/rdc/weflow_server/entity/post/PostQuestionOption.java
+++ b/src/main/java/com/rdc/weflow_server/entity/post/PostQuestionOption.java
@@ -1,0 +1,29 @@
+package com.rdc.weflow_server.entity.post;
+
+import com.rdc.weflow_server.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "post_question_options")
+@Entity
+public class PostQuestionOption extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 옵션 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private PostQuestion question; // 질문 ID
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String optionText; // 옵션 텍스트
+
+    @Column(nullable = false)
+    private Boolean hasInput = false; // 기타 입력 허용 여부 (객관식에서만 사용)
+
+}

--- a/src/main/java/com/rdc/weflow_server/entity/post/QuestionType.java
+++ b/src/main/java/com/rdc/weflow_server/entity/post/QuestionType.java
@@ -1,0 +1,7 @@
+package com.rdc.weflow_server.entity.post;
+
+public enum QuestionType {
+    SINGLE,  // 객관식 (1개 선택)
+    MULTI,   // 객관식 복수선택
+    TEXT     // 주관식
+}

--- a/src/main/java/com/rdc/weflow_server/exception/ErrorCode.java
+++ b/src/main/java/com/rdc/weflow_server/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 
     // Post Question
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_001", "질문을 찾을 수 없습니다."),
+    INVALID_QUESTION_TYPE(HttpStatus.BAD_REQUEST, "QUESTION_002", "유효하지 않은 질문 타입입니다. SINGLE, MULTI, TEXT 중 하나를 입력하세요."),
 
     // Post Answer
     ANSWER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ANSWER_001", "이미 답변이 등록되었습니다."),

--- a/src/main/java/com/rdc/weflow_server/repository/post/PostQuestionOptionRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/post/PostQuestionOptionRepository.java
@@ -1,0 +1,9 @@
+package com.rdc.weflow_server.repository.post;
+
+import com.rdc.weflow_server.entity.post.PostQuestionOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostQuestionOptionRepository extends JpaRepository<PostQuestionOption, Long> {
+}


### PR DESCRIPTION
## Summary

  게시글의 질문-답변 시스템을 기존의 단순한 Yes/No 방식에서 -> 객관식(단일선택/복수선택) 및 주관식을 지원하는 설문 형식으로 개선
  ## Changes

  ### 1. 새로운 엔티티 및 타입 추가
  - `QuestionType` enum 추가 (SINGLE, MULTI, TEXT)
  - `PostQuestionOption` 엔티티 및 `PostQuestionOptionRepository` 추가
  - 질문별 선택지 관리 기능 구현

  ### 2. 엔티티 구조 변경
  - `PostQuestion`: `confirmLabel`, `rejectLabel` 필드 제거 → `questionType`, `options` 필드로 대체
  - `PostAnswer`: 답변 저장 형식을 JSON으로 변경 (selectedOptionIds, textInput)

  ### 3. DTO 수정
  - `PostCreateRequest.QuestionRequest`: 질문 옵션 리스트 추가
  - `PostUpdateRequest.QuestionRequest`: 질문 옵션 리스트 추가
  - `PostAnswerRequest`: `answerType`, `content` → `selectedOptionIds`, `textInput`으로 변경
  - `PostDetailResponse`: 질문 옵션 및 답변 구조 변경

  ### 4. Service 로직 개선
  - 질문 생성/수정 시 옵션 저장 로직 cascade 방식으로 통일
  - QuestionType enum 변환 시 대소문자 구분 제거 및 예외 처리 추가
  - 답변 저장/조회 시 JSON 직렬화/역직렬화 처리
  - `INVALID_QUESTION_TYPE` 에러 코드 추가


  ## Breaking Changes

   **API 스펙 변경**
  - POST `/api/projects/{projectId}/posts` 요청/응답 구조 변경
  - PUT `/api/projects/{projectId}/posts/{postId}` 요청/응답 구조 변경
  - GET `/api/projects/{projectId}/posts/{postId}` 응답 구조 변경
  - POST `/api/projects/{projectId}/questions/{questionId}/answer` 요청 구조 변경

  **데이터베이스 스키마 변경**
  - `post_questions` 테이블: `confirm_label`, `reject_label` 컬럼 삭제, `question_type` 컬럼 추가
  - `post_question_options` 테이블 신규 생성
  - `post_answers` 테이블: `content` 컬럼이 JSON 형식으로 저장
