### PR TITLE
fix: S3 credentials property 경로 수정

### DIFF
--- a/src/main/java/com/rdc/weflow_server/config/storage/S3Config.java
+++ b/src/main/java/com/rdc/weflow_server/config/storage/S3Config.java
@@ -12,13 +12,13 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.access-key:AKIAIOSFODNN7EXAMPLE}")
+    @Value("${cloud.aws.credentials.access-key:AKIAIOSFODNN7EXAMPLE}")
     private String accessKey;
 
-    @Value("${cloud.aws.secret-key:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY}")
+    @Value("${cloud.aws.credentials.secret-key:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY}")
     private String secretKey;
 
-    @Value("${cloud.aws.region:ap-northeast-2}")
+    @Value("${cloud.aws.region.static:ap-northeast-2}")
     private String region;
 
     @Bean


### PR DESCRIPTION
- cloud.aws.access-key → cloud.aws.credentials.access-key
- cloud.aws.secret-key → cloud.aws.credentials.secret-key
- application-prod.yml의 property 경로와 일치하도록 수정
- 환경변수를 정상적으로 읽어오도록 개선