### PR TITLE
feat: 회원 검색 조건에 회사명 추가 (관리자용)

### DIFF
--- a/src/main/java/com/rdc/weflow_server/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/com/rdc/weflow_server/repository/user/UserRepositoryImpl.java
@@ -69,10 +69,12 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 
     // --- 동적 쿼리 조건 메서드들 ---
 
-    // 키워드 검색 (이름 OR 이메일 포함)
+    // 키워드 검색 (이름 OR 이메일 OR 회사명 포함)
     private BooleanExpression keywordContains(String keyword) {
         return StringUtils.hasText(keyword)
-                ? user.name.contains(keyword).or(user.email.contains(keyword))
+                ? user.name.contains(keyword)
+                    .or(user.email.contains(keyword))
+                    .or(user.company.name.contains(keyword))
                 : null;
     }
 


### PR DESCRIPTION
## 작업 요약
- 관리자 페이지의 회원 목록 조회 API에서 검색 키워드(`keyword`)의 적용 범위를 회사명까지 확장했습니다.

## 주요 변경 사항
- **검색 로직 수정 (`UserRepositoryImpl`)**:
  - 기존: 이름(`name`), 이메일(`email`)에 키워드가 포함되는지 확인
  - 변경: 이름, 이메일, **회사명(`company.name`)** 중 하나라도 키워드가 포함되면 검색되도록 `keywordContains` 메서드 수정

## 해결된 문제
- 관리자가 특정 회사의 소속 직원들을 찾고 싶을 때, 기존에는 이름이나 이메일로만 검색이 가능했으나 이제 회사명으로도 쉽게 검색할 수 있습니다.