### PR TITLE
feat: virtual thread

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  threads:
+    virtual:
+      enabled: true
   servlet:
     multipart:
       max-file-size: 5MB


### PR DESCRIPTION
- Enable Java 21 virtual threads to improve concurrent handling of I/O-bound operations such as DB queries, file uploads, and email sending

## Summary
  - Enable Java 21 virtual threads by adding `spring.threads.virtual.enabled: true` to application.yml
  - Improves concurrent request handling for I/O-bound operations

  ## Background
  The server performs numerous I/O-bound operations including:
  - Database queries (posts, checklists, projects)
  - File uploads to S3
  - Email notifications via SMTP
  - HTTP request/response handling

  Virtual threads are lightweight threads that use significantly less memory than platform threads and can handle thousands of concurrent requests efficiently.

  ## Changes
  - Added virtual thread configuration in `application.yml`
  - All Tomcat HTTP request handlers will now use virtual threads instead of platform threads

  ## Benefits
  - **Increased throughput**: Handle more concurrent requests with the same hardware
  - **Reduced memory usage**: Virtual threads use KB instead of MB per thread
  - **Better resource utilization**: Improved handling of I/O wait times
