### PR TITLE
fix: post edit preserve attachments

### DIFF
--- a/src/main/java/com/rdc/weflow_server/dto/post/PostUpdateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostUpdateRequest.java
@@ -21,6 +21,7 @@ public class PostUpdateRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class FileRequest {
+        private Long fileId;  // 기존 파일 ID (있으면 기존 파일 유지, 없으면 새 파일)
         private String fileName;
         private Long fileSize;
         private String filePath;
@@ -31,6 +32,7 @@ public class PostUpdateRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LinkRequest {
+        private Long linkId;  // 기존 링크 ID (있으면 기존 링크 유지, 없으면 새 링크)
         private String url;
     }
 


### PR DESCRIPTION
- PostUpdateRequest에 fileId, linkId 필드 추가하여 기존 항목 식별 가능
- 수정 요청 시 ID 기반으로 기존 파일/링크 선택적 유지
- 프론트엔드에서 수정 폼 진입 시 기존 첨부파일 유지 가능