### PR TITLE
refactor: 승인요청 첨부 keepIds 지원 및 수정일 응답 추가

### DIFF
--- a/src/main/java/com/rdc/weflow_server/dto/step/StepRequestResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/step/StepRequestResponse.java
@@ -28,4 +28,5 @@ public class StepRequestResponse {
     private String decisionReason;
     private List<AttachmentSimpleResponse> attachments;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/rdc/weflow_server/dto/step/StepRequestSummaryResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/step/StepRequestSummaryResponse.java
@@ -19,6 +19,7 @@ public class StepRequestSummaryResponse {
     private StepRequestStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime decidedAt;
+    private LocalDateTime updatedAt;
     private Long projectId;
     private String projectName;
     private ProjectPhase phase;
@@ -35,6 +36,7 @@ public class StepRequestSummaryResponse {
                 .status(sr.getStatus())
                 .createdAt(sr.getCreatedAt())
                 .decidedAt(sr.getDecidedAt())
+                .updatedAt(sr.getUpdatedAt())
                 .projectId(sr.getStep().getProject().getId())
                 .projectName(sr.getStep().getProject().getName())
                 .phase(sr.getStep().getPhase())

--- a/src/main/java/com/rdc/weflow_server/dto/step/StepRequestUpdateRequest.java
+++ b/src/main/java/com/rdc/weflow_server/dto/step/StepRequestUpdateRequest.java
@@ -24,6 +24,12 @@ public class StepRequestUpdateRequest {
     @Size(max = 50)
     private List<LinkRequest> links;
 
+    /** 유지할 기존 파일 ID 목록 (null이면 기존 전체교체 방식, 빈 배열이면 전체 삭제) */
+    private List<Long> keepFileIds;
+
+    /** 유지할 기존 링크 ID 목록 (null이면 기존 전체교체 방식, 빈 배열이면 전체 삭제) */
+    private List<Long> keepLinkIds;
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/com/rdc/weflow_server/repository/attachment/AttachmentRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/attachment/AttachmentRepository.java
@@ -27,6 +27,13 @@ public interface AttachmentRepository extends JpaRepository<Attachment, Long> {
             Attachment.AttachmentType attachmentType
     );
 
+    void deleteByTargetTypeAndTargetIdAndAttachmentTypeAndIdNotIn(
+            Attachment.TargetType targetType,
+            Long targetId,
+            Attachment.AttachmentType attachmentType,
+            List<Long> keepIds
+    );
+
     @org.springframework.data.jpa.repository.Query("""
             select distinct a.targetId
             from Attachment a

--- a/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
@@ -458,6 +458,7 @@ public class StepRequestService {
                         .orElse(null))
                 .attachments(getAttachments(stepRequest))
                 .createdAt(stepRequest.getCreatedAt())
+                .updatedAt(stepRequest.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepRequestService.java
@@ -143,14 +143,12 @@ public class StepRequestService {
             stepRequest.updateDescription(request.getDescription());
         }
 
-        // 파일 첨부 동기화 (null이면 유지, 빈 리스트면 모두 제거)
-        if (request.getFiles() != null) {
-            syncRequestFiles(stepRequest, toFilePayloads(request.getFiles()), ctx);
+        // 파일/링크 첨부 동기화
+        if (request.getFiles() != null || request.getKeepFileIds() != null) {
+            syncRequestFiles(stepRequest, request, ctx);
         }
-
-        // 링크 첨부 동기화 (null이면 유지, 빈 리스트면 모두 제거)
-        if (request.getLinks() != null) {
-            syncRequestLinks(stepRequest, toLinkPayloads(request.getLinks()), ctx);
+        if (request.getLinks() != null || request.getKeepLinkIds() != null) {
+            syncRequestLinks(stepRequest, request, ctx);
         }
 
         // CHANGE_REQUESTED -> REQUESTED 재요청 전이
@@ -265,6 +263,58 @@ public class StepRequestService {
         notifyClients(stepRequest, NotificationType.STEP_REQUEST, step.getTitle(), "승인 요청이 취소되었습니다.");
     }
 
+    private void syncRequestFiles(StepRequest stepRequest, StepRequestUpdateRequest request, AuditContext ctx) {
+        List<Long> keepFileIds = request.getKeepFileIds();
+        List<SimpleFilePayload> files = toFilePayloads(request.getFiles());
+
+        if (keepFileIds == null) { // 하위호환: 전체 교체
+            attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentType(
+                    Attachment.TargetType.STEP_REQUEST,
+                    stepRequest.getId(),
+                    Attachment.AttachmentType.FILE
+            );
+        } else if (keepFileIds.isEmpty()) {
+            attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentType(
+                    Attachment.TargetType.STEP_REQUEST,
+                    stepRequest.getId(),
+                    Attachment.AttachmentType.FILE
+            );
+        } else {
+            attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentTypeAndIdNotIn(
+                    Attachment.TargetType.STEP_REQUEST,
+                    stepRequest.getId(),
+                    Attachment.AttachmentType.FILE,
+                    keepFileIds
+            );
+        }
+
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+
+        for (SimpleFilePayload file : files) {
+            validateFilePayload(file);
+            Attachment attachment = Attachment.builder()
+                    .targetType(Attachment.TargetType.STEP_REQUEST)
+                    .targetId(stepRequest.getId())
+                    .attachmentType(Attachment.AttachmentType.FILE)
+                    .fileName(file.fileName())
+                    .fileSize(file.fileSize())
+                    .filePath(file.filePath())
+                    .contentType(file.contentType())
+                    .build();
+            attachmentRepository.save(attachment);
+            activityLogService.createLog(
+                    ActionType.UPLOAD,
+                    TargetTable.ATTACHMENT,
+                    attachment.getId(),
+                    ctx.userId(),
+                    stepRequest.getStep().getProject().getId(),
+                    ctx.ipAddress()
+            );
+        }
+    }
+
     private void syncRequestFiles(StepRequest stepRequest, List<SimpleFilePayload> files, AuditContext ctx) {
         if (files == null) {
             return;
@@ -290,6 +340,55 @@ public class StepRequestService {
                     .fileSize(file.fileSize())
                     .filePath(file.filePath())
                     .contentType(file.contentType())
+                    .build();
+            attachmentRepository.save(attachment);
+            activityLogService.createLog(
+                    ActionType.UPLOAD,
+                    TargetTable.ATTACHMENT,
+                    attachment.getId(),
+                    ctx.userId(),
+                    stepRequest.getStep().getProject().getId(),
+                    ctx.ipAddress()
+            );
+        }
+    }
+
+    private void syncRequestLinks(StepRequest stepRequest, StepRequestUpdateRequest request, AuditContext ctx) {
+        List<Long> keepLinkIds = request.getKeepLinkIds();
+        List<SimpleLinkPayload> links = toLinkPayloads(request.getLinks());
+
+        if (keepLinkIds == null) { // 하위호환: 전체 교체
+            attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentType(
+                    Attachment.TargetType.STEP_REQUEST,
+                    stepRequest.getId(),
+                    Attachment.AttachmentType.LINK
+            );
+        } else if (keepLinkIds.isEmpty()) {
+            attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentType(
+                    Attachment.TargetType.STEP_REQUEST,
+                    stepRequest.getId(),
+                    Attachment.AttachmentType.LINK
+            );
+        } else {
+            attachmentRepository.deleteByTargetTypeAndTargetIdAndAttachmentTypeAndIdNotIn(
+                    Attachment.TargetType.STEP_REQUEST,
+                    stepRequest.getId(),
+                    Attachment.AttachmentType.LINK,
+                    keepLinkIds
+            );
+        }
+
+        if (links == null || links.isEmpty()) {
+            return;
+        }
+
+        for (SimpleLinkPayload link : links) {
+            validateLinkPayload(link);
+            Attachment attachment = Attachment.builder()
+                    .targetType(Attachment.TargetType.STEP_REQUEST)
+                    .targetId(stepRequest.getId())
+                    .attachmentType(Attachment.AttachmentType.LINK)
+                    .url(link.url())
                     .build();
             attachmentRepository.save(attachment);
             activityLogService.createLog(


### PR DESCRIPTION

  ## 변경
  - StepRequest 수정 API에 keepFileIds/keepLinkIds 추가, 부분 업데이트 지원(keepIds null 시 기존 전체교체 유지)
  - 첨부 삭제 로직: keepIds 기준 NOT IN 삭제 후 신규 파일/링크만 추가
  - StepRequest/목록 응답에 updatedAt 추가
  - 승인 요청 생성/수정 시 첨부 동기화 호출을 분리해 타입 오류 해결
  - (보완 필요) keepIds 대상 검증은 현재 미적용

  ## 확인/테스트 포인트
  - 첨부 필드 미포함 시 기존 첨부 유지
  - keepIds만/keepIds+추가/keepIds=[]/링크 동일 케이스
  - 목록/상세 응답에 updatedAt 포함 여부