### PR TITLE
 fix: 완료된 Phase 단계 생성 차단 및 완료 판정 매핑 보완

### DIFF
--- a/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
+++ b/src/main/java/com/rdc/weflow_server/repository/step/StepRepository.java
@@ -69,6 +69,18 @@ public interface StepRepository extends JpaRepository<Step, Long> {
 
     boolean existsByProject_IdAndPhaseAndOrderIndexAndDeletedAtIsNull(Long projectId, ProjectPhase phase, Integer orderIndex);
 
+    @Query("""
+            select case when count(s) > 0
+                        and sum(case when s.status = com.rdc.weflow_server.entity.step.StepStatus.APPROVED then 1 else 0 end) = count(s)
+                        then true else false end
+            from Step s
+            where s.project.id = :projectId
+              and s.phase = :phase
+              and s.deletedAt is null
+            """)
+    Boolean isPhaseCompleted(@org.springframework.data.repository.query.Param("projectId") Long projectId,
+                             @org.springframework.data.repository.query.Param("phase") ProjectPhase phase);
+
     Optional<Step> findByIdAndDeletedAtIsNull(Long id);
     @Query("""
             select s from Step s

--- a/src/main/java/com/rdc/weflow_server/service/step/StepService.java
+++ b/src/main/java/com/rdc/weflow_server/service/step/StepService.java
@@ -100,6 +100,9 @@ public class StepService {
         }
 
         ProjectPhase phase = request.getPhase() != null ? request.getPhase() : ProjectPhase.IN_PROGRESS;
+        if (Boolean.TRUE.equals(stepRepository.isPhaseCompleted(projectId, phase))) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "완료된 단계에는 스텝을 추가할 수 없습니다.");
+        }
         Integer orderIndex = resolveOrderIndex(projectId, phase, request.getOrderIndex());
         StepStatus status = StepStatus.PENDING;
 


### PR DESCRIPTION
 ## 변경
  - Phase 완료 여부를 JPQL로 계산하는 isPhaseCompleted에 @Param을 명시해 안전하게 매핑
  - Step 생성 시 해당 phase가 완료(스텝 존재 && 전부 APPROVED)인 경우 생성 차단

  ## 참고
  - resolveOrderIndex는 deletedAt is null 기준이라 완료 판정과 삭제 기준이 일관
  - 에러 코드는 INVALID_INPUT_VALUE + 메시지로 처리 중 (별도 코드 필요 시 조정)