### PR TITLE
fix: post response-dto

### DIFF
--- a/src/main/java/com/rdc/weflow_server/dto/post/PostListResponse.java
+++ b/src/main/java/com/rdc/weflow_server/dto/post/PostListResponse.java
@@ -32,8 +32,8 @@ public class PostListResponse {
         private ProjectPhase projectPhase;
         private Long stepId;
         private AuthorDto author;
-        private Boolean hasFiles;
-        private Boolean hasLinks;
+        private Integer fileCount;
+        private Integer linkCount;
         private Boolean hasQuestions;
         private Integer commentCount;
         private Integer replyCount;


### PR DESCRIPTION
- hasFiles/hasLinks를 fileCount/linkCount로 변경하여 실제 개수 반환
- 댓글 카운트 로직 수정: Post.children 대신 Comment 엔티티 사용
- 삭제된 댓글/답글은 카운트에서 제외하도록 필터링 추가