### PR TITLE
perf: 게시글 목록 조회 OFFSET 페이징 성능 개선을 위한 인덱스 추가

### DIFF
--- a/docs/sql/posts/posts_offset_indexes.sql
+++ b/docs/sql/posts/posts_offset_indexes.sql
@@ -1,0 +1,84 @@
+/* =========================================================
+   posts 목록 조회(OFFSET Pagination) 성능 개선 인덱스
+   ---------------------------------------------------------
+   대상 API:
+   - GET /api/projects/{projectId}/posts
+   - PostRepository 기반 게시글 목록 조회
+
+   공통 쿼리 패턴:
+   - posts p
+     JOIN steps s ON p.step_id = s.id
+     WHERE s.project_id = :projectId
+       AND p.deleted_at IS NULL
+       [AND p.step_id = :stepId]
+       [AND p.project_phase = :projectPhase]
+       [AND p.open_status = :openStatus]
+     ORDER BY p.created_at DESC, p.id DESC
+     LIMIT :size OFFSET :offset
+
+   목적:
+   - OFFSET 페이지네이션에서 filesort / 불필요한 스캔 최소화
+   - stepId / projectPhase / openStatus 조합별 조회 성능 개선
+   - 실제 사용되는 쿼리 패턴에 맞춰 최소 개수로 인덱스 구성
+
+   주의:
+   - MySQL 8 기준
+   - 운영/RDS에서는 인덱스 생성 시 잠금/시간 소요 가능
+   - 적용 전 SHOW INDEX FROM posts; 로 중복 여부 확인 권장
+   ========================================================= */
+
+-- =========================================================
+-- 1) stepId 기반 조회
+-- ---------------------------------------------------------
+-- 사용 케이스:
+--   WHERE p.step_id = ?
+--     AND p.deleted_at IS NULL
+--   ORDER BY p.created_at DESC, p.id DESC
+--
+-- 효과:
+--   - 특정 단계 게시글 목록 조회
+--   - 기본 정렬(createdAt DESC) + OFFSET 페이징 최적화
+-- =========================================================
+CREATE INDEX idx_posts_step_del_created_id
+    ON posts (step_id, deleted_at, created_at DESC, id DESC);
+
+
+-- =========================================================
+-- 2) stepId + openStatus 조회
+-- ---------------------------------------------------------
+-- 사용 케이스:
+--   WHERE p.step_id = ?
+--     AND p.open_status = ?
+--     AND p.deleted_at IS NULL
+--   ORDER BY p.created_at DESC, p.id DESC
+--
+-- 효과:
+--   - 단계별 + 공개/비공개(Open/Closed) 필터 조회
+--   - openStatus 조건 포함 시 추가 스캔 제거
+-- =========================================================
+CREATE INDEX idx_posts_step_open_del_created_id
+    ON posts (step_id, open_status, deleted_at, created_at DESC, id DESC);
+
+
+-- =========================================================
+-- 3) stepId + projectPhase (+ openStatus) 조회
+-- ---------------------------------------------------------
+-- 사용 케이스:
+--   WHERE p.step_id = ?
+--     AND p.project_phase = ?
+--     [AND p.open_status = ?]
+--     AND p.deleted_at IS NULL
+--   ORDER BY p.created_at DESC, p.id DESC
+--
+-- 효과:
+--   - 프로젝트 Phase 탭 + 단계 필터 조합 조회
+--   - phase + openStatus 조건이 함께 오는 경우까지 커버
+-- =========================================================
+CREATE INDEX idx_posts_step_phase_open_del_created_id
+    ON posts (step_id, project_phase, open_status, deleted_at, created_at DESC, id DESC);
+
+
+-- =========================================================
+-- (선택) 적용 결과 확인
+-- =========================================================
+-- SHOW INDEX FROM posts;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://127.0.0.1:3307/weflow_local?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: 1234
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 변경 내용

게시글 목록 조회 API(`/api/projects/{projectId}/posts`)의
OFFSET 기반 페이지네이션 성능 개선을 위해
조회 패턴에 맞는 posts 복합 인덱스를 추가했습니다.

### 추가된 인덱스
- stepId 기반 조회
- stepId + openStatus 조회
- stepId + projectPhase(+openStatus) 조회
- deleted_at IS NULL + createdAt DESC 정렬까지 커버

```sql
CREATE INDEX idx_posts_step_del_created_id
    ON posts (step_id, deleted_at, created_at DESC, id DESC);

CREATE INDEX idx_posts_step_open_del_created_id
    ON posts (step_id, open_status, deleted_at, created_at DESC, id DESC);

CREATE INDEX idx_posts_step_phase_open_del_created_id
    ON posts (step_id, project_phase, open_status, deleted_at, created_at DESC, id DESC);

### 기대 효과
- 게시글 목록 조회 시 filesort/불필요한 스캔 감소
- OFFSET 페이징 초반~중간 페이지 응답 안정화

API/비즈니스 로직 변경 없이 인덱스만 추가했습니다.